### PR TITLE
Support dynamically sourcing discovery rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifndef TEMP_DIR
 TEMP_DIR:=$(shell mktemp -d /tmp/wavefront.XXXXXX)
 endif
 
-VERSION?=1.1.3
+VERSION?=1.2.0
 GIT_COMMIT:=$(shell git rev-parse --short HEAD)
 
 REPO_DIR:=$(shell pwd)

--- a/cmd/wavefront-collector/main.go
+++ b/cmd/wavefront-collector/main.go
@@ -200,7 +200,7 @@ func fillDefaults(cfg *configuration.Config) {
 		cfg.ClusterName = "k8s-cluster"
 	}
 	if cfg.DiscoveryConfig.DiscoveryInterval == 0 {
-		cfg.DiscoveryConfig.DiscoveryInterval = 10 * time.Minute
+		cfg.DiscoveryConfig.DiscoveryInterval = 5 * time.Minute
 	}
 }
 

--- a/internal/discovery/configs.go
+++ b/internal/discovery/configs.go
@@ -11,13 +11,17 @@ import (
 
 // configuration for auto discovery
 type Config struct {
-	// frequency of evaluating discovery rules. Defaults to 10 minutes.
+	// frequency of evaluating discovery rules. Defaults to 5 minutes.
 	// format is [0-9]+(ms|[smhdwy])
 	DiscoveryInterval time.Duration `yaml:"discovery_interval"`
 
 	// the annotation prefix for annotations based discovery
 	// if specified, this substitutes the default prefix such as "prometheus.io" etc that is used during discovery
 	AnnotationPrefix string `yaml:"annotation_prefix"`
+
+	// enables support for sourcing plugin configurations dynamically from configmaps
+	// with the annotation "wavefront.com/discovery-config: 'true'". Defaults to false.
+	EnableRuntimePlugins bool `yaml:"enable_runtime_plugins"`
 
 	// list of discovery rules
 	PluginConfigs []PluginConfig `yaml:"plugins"`

--- a/plugins/discovery/config.go
+++ b/plugins/discovery/config.go
@@ -1,0 +1,188 @@
+package discovery
+
+import (
+	"reflect"
+	"sort"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/discovery"
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/util"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	discoveryAnnotation = "wavefront.com/discovery-config"
+)
+
+type configHandler struct {
+	ch       chan struct{}
+	informer cache.SharedInformer
+
+	mtx         sync.RWMutex
+	cfg         discovery.Config            // main configuration obtained by combining wired and dynamic configuration
+	wiredCfg    discovery.Config            // wired configuration
+	runtimeCfgs map[string]discovery.Config // dynamic runtime configurations
+	changed     bool                        // flag for tracking runtime cfg changes
+}
+
+func newConfigHandler(kubeClient kubernetes.Interface, cfg discovery.Config) *configHandler {
+	handler := &configHandler{
+		cfg:         cfg,
+		wiredCfg:    cfg,
+		runtimeCfgs: make(map[string]discovery.Config),
+	}
+
+	ns := util.GetNamespaceName()
+	if ns == "" {
+		return handler
+	}
+
+	s := kubeClient.CoreV1().ConfigMaps(ns)
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return s.List(options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return s.Watch(options)
+		},
+	}
+
+	inf := cache.NewSharedInformer(lw, &v1.ConfigMap{}, 1*time.Hour)
+	inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			cfg := obj.(*v1.ConfigMap)
+			handler.updated(cfg)
+		},
+		UpdateFunc: func(_, obj interface{}) {
+			cfg := obj.(*v1.ConfigMap)
+			handler.updated(cfg)
+		},
+		DeleteFunc: func(obj interface{}) {
+			cfg := obj.(*v1.ConfigMap)
+			handler.deleted(cfg)
+		},
+	})
+
+	handler.informer = inf
+	return handler
+}
+
+// Config gets the combined discovery configuration and a boolean indicating whether
+// the configuration has changed since the last call to this function
+func (handler *configHandler) Config() (discovery.Config, bool) {
+	handler.mtx.Lock()
+	defer handler.mtx.Unlock()
+
+	if !handler.changed {
+		return handler.cfg, false
+	}
+	handler.changed = false
+
+	newCfg := combine(handler.wiredCfg, handler.runtimeCfgs)
+	if !reflect.DeepEqual(handler.cfg, newCfg) {
+		// update the main combined config
+		handler.cfg = newCfg
+		return handler.cfg, true
+	}
+	return handler.cfg, false
+}
+
+func (handler *configHandler) updated(cmap *v1.ConfigMap) {
+	if !annotated(cmap.GetAnnotations()) {
+		// delegate to deleted and return
+		log.Infof("no runtime annotation on %s", cmap.Name)
+		handler.deleted(cmap)
+		return
+	}
+
+	loaded, err := load(cmap)
+	if err != nil {
+		log.Errorf("error loading discovery config: %s error: %v", cmap.Name, err)
+		return
+	}
+	log.Infof("loaded discovery configuration from %s", cmap.Name)
+
+	handler.mtx.Lock()
+	defer handler.mtx.Unlock()
+
+	// update the internal map entry
+	handler.runtimeCfgs[cmap.Name] = loaded
+	handler.changed = true
+}
+
+func (handler *configHandler) deleted(cmap *v1.ConfigMap) {
+	handler.mtx.Lock()
+	defer handler.mtx.Unlock()
+	if _, found := handler.runtimeCfgs[cmap.Name]; found {
+		log.Infof("deleted discovery configuration from %s", cmap.Name)
+		delete(handler.runtimeCfgs, cmap.Name)
+		handler.changed = true
+	}
+}
+
+func annotated(annotations map[string]string) bool {
+	if val, ok := annotations[discoveryAnnotation]; ok {
+		return val == "true"
+	}
+	return false
+}
+
+func load(cmap *v1.ConfigMap) (discovery.Config, error) {
+	cfg := &discovery.Config{}
+	for _, data := range cmap.Data {
+		loadedCfg, err := discovery.FromYAML([]byte(data))
+		if err != nil {
+			return *cfg, err
+		}
+		cfg.PluginConfigs = append(cfg.PluginConfigs, loadedCfg.PluginConfigs...)
+	}
+	return *cfg, nil
+}
+
+func combine(cfg discovery.Config, cfgs map[string]discovery.Config) discovery.Config {
+	runCfg := &discovery.Config{
+		DiscoveryInterval: cfg.DiscoveryInterval,
+		AnnotationPrefix:  cfg.AnnotationPrefix,
+		PluginConfigs:     cfg.PluginConfigs,
+	}
+
+	// build a sorted slice of map keys for consistent iteration order
+	keys := make([]string, len(cfgs))
+	i := 0
+	for k := range cfgs {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+
+	log.Debug("combining discovery configurations")
+	for _, key := range keys {
+		c := cfgs[key]
+		if len(c.PluginConfigs) > 0 {
+			runCfg.PluginConfigs = append(runCfg.PluginConfigs, c.PluginConfigs...)
+		}
+	}
+	log.Debugf("total plugin configs: %d", len(runCfg.PluginConfigs))
+	return *runCfg
+}
+
+func (handler *configHandler) start() bool {
+	handler.ch = make(chan struct{})
+	go handler.informer.Run(handler.ch)
+	return cache.WaitForCacheSync(handler.ch, handler.informer.HasSynced)
+}
+
+func (handler *configHandler) stop() {
+	if handler.ch != nil {
+		close(handler.ch)
+	}
+}

--- a/plugins/discovery/config.go
+++ b/plugins/discovery/config.go
@@ -24,7 +24,7 @@ const (
 )
 
 type configHandler struct {
-	ch       chan struct{}
+	stopCh   chan struct{}
 	informer cache.SharedInformer
 
 	mtx         sync.RWMutex
@@ -176,13 +176,13 @@ func combine(cfg discovery.Config, cfgs map[string]discovery.Config) discovery.C
 }
 
 func (handler *configHandler) start() bool {
-	handler.ch = make(chan struct{})
-	go handler.informer.Run(handler.ch)
-	return cache.WaitForCacheSync(handler.ch, handler.informer.HasSynced)
+	handler.stopCh = make(chan struct{})
+	go handler.informer.Run(handler.stopCh)
+	return cache.WaitForCacheSync(handler.stopCh, handler.informer.HasSynced)
 }
 
 func (handler *configHandler) stop() {
-	if handler.ch != nil {
-		close(handler.ch)
+	if handler.stopCh != nil {
+		close(handler.stopCh)
 	}
 }

--- a/plugins/discovery/config_test.go
+++ b/plugins/discovery/config_test.go
@@ -1,0 +1,153 @@
+package discovery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/discovery"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var sampleConfigString = `
+plugins:
+  - type: telegraf/redis
+    name: "redis"
+    selectors:
+      images:
+      - 'redis:*'
+      - '*redis*'
+    port: 6379
+    scheme: "tcp"
+    conf: |
+      servers = [${server}]
+      password = bar
+  - type: telegraf/memcached
+    name: "memcached"
+    selectors:
+      images:
+      - 'memcached:*'
+    port: 11211
+    conf: |
+      servers = ${server}
+  - type: prometheus
+    name: kube-dns
+    selectors:
+      labels:
+        k8s-app: 
+        - kube-dns      
+    port: 10054
+    path: /metrics
+    scheme: http
+    prefix: kube.dns.
+    tags:
+      env: prod
+    filters:
+      metricWhitelist:
+      - '*foo*'
+      - 'bar*'
+      metricBlacklist:
+      - 'kube.dns.go.*'
+      - 'kube.dns.probe.*'
+      metricTagWhitelist:
+        env:
+        - 'prod1*'
+        - 'prod2*'
+        service:
+        - 'app1*'
+        - '?app2*'
+`
+
+func TestLoad(t *testing.T) {
+	cmap := makeCfgMap("test", map[string]string{"plugins": sampleConfigString})
+	cfg, err := load(cmap)
+	assert.NoError(t, err)
+	assert.True(t, len(cfg.PluginConfigs) == 3)
+}
+
+func TestCombine(t *testing.T) {
+	cfg := &discovery.Config{
+		DiscoveryInterval: time.Duration(10 * time.Minute),
+		AnnotationPrefix:  "wavefront.com",
+		PluginConfigs:     makePlugins(3, "main"),
+	}
+
+	plugins := map[string]discovery.Config{
+		"memcached": {PluginConfigs: makePlugins(3, "memcached")},
+		"redis":     {PluginConfigs: makePlugins(2, "redis")},
+	}
+	result := combine(*cfg, plugins)
+	assert.Equal(t, 8, len(result.PluginConfigs))
+
+	result = combine(*cfg, nil)
+	assert.Equal(t, 3, len(result.PluginConfigs))
+
+	cfg.PluginConfigs = nil
+	result = combine(*cfg, plugins)
+	assert.Equal(t, 5, len(result.PluginConfigs))
+}
+
+func TestAdd(t *testing.T) {
+	ch := makeFakeConfigHandler(discovery.Config{PluginConfigs: makePlugins(2, "main")})
+	cmap := makeCfgMap("test", map[string]string{"plugins": sampleConfigString})
+
+	// no changes as missing annotation on cmap
+	ch.updated(cmap)
+	assert.True(t, ch.changed == false)
+
+	// changes when annotation is present
+	cmap.SetAnnotations(map[string]string{discoveryAnnotation: "true"})
+	ch.updated(cmap)
+	assert.True(t, ch.changed)
+
+	cfg, changed := ch.Config()
+	assert.True(t, changed)
+	assert.Equal(t, 5, len(cfg.PluginConfigs))
+}
+
+func TestDelete(t *testing.T) {
+	ch := makeFakeConfigHandler(discovery.Config{PluginConfigs: makePlugins(2, "main")})
+	cmap := makeCfgMap("test", map[string]string{"plugins": sampleConfigString})
+	cmap.SetAnnotations(map[string]string{discoveryAnnotation: "true"})
+	ch.updated(cmap)
+
+	cfg, changed := ch.Config()
+	assert.True(t, changed)
+	assert.Equal(t, 5, len(cfg.PluginConfigs))
+
+	// delete the config map and validate the plugins are removed
+	ch.deleted(cmap)
+	cfg, changed = ch.Config()
+	assert.True(t, changed)
+	assert.Equal(t, 2, len(cfg.PluginConfigs))
+}
+
+func makeFakeConfigHandler(wired discovery.Config) *configHandler {
+	return &configHandler{
+		wiredCfg:    wired,
+		runtimeCfgs: make(map[string]discovery.Config),
+	}
+}
+
+func makePlugins(n int, prefix string) []discovery.PluginConfig {
+	plugins := make([]discovery.PluginConfig, n)
+	for i := 0; i < n; i++ {
+		plugins[0] = discovery.PluginConfig{
+			Name: prefix + "-plugin-" + string(i),
+			Type: "prometheus",
+		}
+	}
+	return plugins
+}
+
+func makeCfgMap(name string, data map[string]string) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Data: data,
+	}
+}

--- a/plugins/discovery/manager.go
+++ b/plugins/discovery/manager.go
@@ -75,7 +75,7 @@ func (dm *Manager) Start() {
 		cfg, _ = dm.configListener.Config()
 	}
 	dm.discoverer = newDiscoverer(dm.runConfig.Handler, cfg, dm.runConfig.Lister)
-	dm.resyncConfig()
+	dm.startResyncConfig()
 
 	// init discovery handlers
 	dm.podListener = newPodHandler(dm.runConfig.KubeClient, dm.discoverer)
@@ -117,9 +117,9 @@ func (dm *Manager) Pause() {
 	dm.serviceListener.stop()
 }
 
-// resyncConfig periodically checks for changes to the discovery config.
+// startResyncConfig periodically checks for changes to the discovery config.
 // It stops monitoring existing resources and reloads the discovery manager on changes
-func (dm *Manager) resyncConfig() {
+func (dm *Manager) startResyncConfig() {
 	if !dm.runConfig.DiscoveryConfig.EnableRuntimePlugins {
 		log.Info("runtime plugins disabled")
 		return

--- a/plugins/discovery/manager.go
+++ b/plugins/discovery/manager.go
@@ -12,6 +12,7 @@ import (
 
 	gm "github.com/rcrowley/go-metrics"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -40,6 +41,7 @@ type RunConfig struct {
 type Manager struct {
 	runConfig       RunConfig
 	discoverer      discovery.Discoverer
+	configListener  *configHandler
 	podListener     *podHandler
 	serviceListener *serviceHandler
 	leadershipMgr   *leadership.Manager
@@ -49,9 +51,8 @@ type Manager struct {
 // NewDiscoveryManager creates a new instance of a discovery manager based on the given configuration.
 func NewDiscoveryManager(cfg RunConfig) *Manager {
 	mgr := &Manager{
-		runConfig:  cfg,
-		stopCh:     make(chan struct{}),
-		discoverer: newDiscoverer(cfg.Handler, cfg.DiscoveryConfig, cfg.Lister),
+		runConfig: cfg,
+		stopCh:    make(chan struct{}),
 	}
 	mgr.leadershipMgr = leadership.NewManager(mgr, subscriberName, cfg.KubeClient)
 	return mgr
@@ -62,6 +63,19 @@ func (dm *Manager) Start() {
 	discoveryEnabled.Inc(1)
 
 	dm.stopCh = make(chan struct{})
+
+	// init configuration file and discoverer
+	cfg := dm.runConfig.DiscoveryConfig
+	if cfg.EnableRuntimePlugins {
+		log.Info("runtime plugins enabled")
+		dm.configListener = newConfigHandler(dm.runConfig.KubeClient, dm.runConfig.DiscoveryConfig)
+		if !dm.configListener.start() {
+			log.Error("timed out waiting for configmap caches to sync")
+		}
+		cfg, _ = dm.configListener.Config()
+	}
+	dm.discoverer = newDiscoverer(dm.runConfig.Handler, cfg, dm.runConfig.Lister)
+	dm.resyncConfig()
 
 	// init discovery handlers
 	dm.podListener = newPodHandler(dm.runConfig.KubeClient, dm.discoverer)
@@ -82,6 +96,9 @@ func (dm *Manager) Stop() {
 	discoveryEnabled.Dec(1)
 
 	leadership.Unsubscribe(subscriberName)
+	if dm.configListener != nil {
+		dm.configListener.stop()
+	}
 	dm.podListener.stop()
 	dm.serviceListener.stop()
 	close(dm.stopCh)
@@ -98,4 +115,26 @@ func (dm *Manager) Resume() {
 func (dm *Manager) Pause() {
 	log.Infof("stopping service discovery. new leader: %s", leadership.Leader())
 	dm.serviceListener.stop()
+}
+
+// resyncConfig periodically checks for changes to the discovery config.
+// It stops monitoring existing resources and reloads the discovery manager on changes
+func (dm *Manager) resyncConfig() {
+	if !dm.runConfig.DiscoveryConfig.EnableRuntimePlugins {
+		log.Info("runtime plugins disabled")
+		return
+	}
+
+	interval := dm.runConfig.DiscoveryConfig.DiscoveryInterval
+	log.Infof("discovery config interval: %v", interval)
+
+	go wait.Until(func() {
+		log.Info("checking for runtime plugin changes")
+		_, changed := dm.configListener.Config()
+		if changed {
+			log.Info("found new runtime plugins")
+			dm.Stop()
+			dm.Start()
+		}
+	}, interval, dm.stopCh)
 }


### PR DESCRIPTION
Added support for dynamically sourcing discovery rules:
- Allows users to add/update/delete specific workload related discovery rules as separate config maps with certain annotations (within the same namespace as collector for now)
- Enabled via `discovery.enable_runtime_plugins` property (defaults to false at this time)
- Added a separate config handler to listen for these changes. And the discovery manager sources these changes every X minutes (configured via `discovery.DiscoveryInterval` which defaults to 5 minutes)

Together with the annotations based discovery we already have, this allows the main config file to be owned/locked down by admins while allowing users to enable monitoring of apps/workloads they own by deploying discovery rules relevant to just that piece.
