### PR TITLE
memory optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifndef TEMP_DIR
 TEMP_DIR:=$(shell mktemp -d /tmp/wavefront.XXXXXX)
 endif
 
-VERSION?=1.2.1
+VERSION?=1.2.2
 GIT_COMMIT:=$(shell git rev-parse --short HEAD)
 
 REPO_DIR:=$(shell pwd)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifndef TEMP_DIR
 TEMP_DIR:=$(shell mktemp -d /tmp/wavefront.XXXXXX)
 endif
 
-VERSION?=1.2.2
+VERSION?=1.2.3
 GIT_COMMIT:=$(shell git rev-parse --short HEAD)
 
 REPO_DIR:=$(shell pwd)

--- a/internal/discovery/endpoint.go
+++ b/internal/discovery/endpoint.go
@@ -43,11 +43,13 @@ func (d *defaultEndpointHandler) Encode(resource Resource, rule PluginConfig) (s
 	ip := resource.IP
 	meta := resource.Meta
 
-	log.WithFields(log.Fields{
-		"kind":      kind,
-		"name":      meta.Name,
-		"namespace": meta.Namespace,
-	}).Debug("handling resource")
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.WithFields(log.Fields{
+			"kind":      kind,
+			"name":      meta.Name,
+			"namespace": meta.Namespace,
+		}).Debug("handling resource")
+	}
 
 	if delegate, ok := d.providers[pluginType(rule)]; ok {
 		return delegate.Encoder.Encode(ip, kind, meta, rule)

--- a/internal/filter/glob.go
+++ b/internal/filter/glob.go
@@ -11,6 +11,7 @@ import (
 
 type Filter interface {
 	Match(name string, tags map[string]string) bool
+	UsesTags() bool
 }
 
 type globFilter struct {
@@ -68,6 +69,11 @@ func MultiSetCompile(filters []map[string][]string) []map[string]glob.Glob {
 		globs[i] = MultiCompile(f)
 	}
 	return globs
+}
+
+func (gf *globFilter) UsesTags() bool {
+	return gf.metricTagWhitelist != nil || gf.metricTagBlacklist != nil ||
+		gf.tagExclude != nil || gf.tagInclude != nil
 }
 
 func (gf *globFilter) Match(name string, tags map[string]string) bool {

--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -21,6 +21,9 @@
 package metrics
 
 import (
+	dto "github.com/prometheus/client_model/go"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -177,7 +180,45 @@ type MetricPoint struct {
 	Timestamp int64
 	Source    string
 	Tags      map[string]string
-	StrTags   string
+
+	// Embed Prometheus labels directly to avoid memory allocations
+	// Converted to map[string]string at sink export time
+	Labels []*dto.LabelPair
+
+	SrcTags map[string]string
+	StrTags string
+}
+
+func (m *MetricPoint) AddCustomTags(tags map[string]string) {
+	for k, v := range m.SrcTags {
+		if len(k) > 0 && len(v) > 0 {
+			tags[k] = v
+		}
+	}
+	for _, label := range m.Labels {
+		k, v := label.GetName(), label.GetValue()
+		if len(k) > 0 && len(v) > 0 {
+			tags[k] = v
+		}
+	}
+
+	if len(m.StrTags) > 0 {
+		for _, tag := range strings.Split(m.StrTags, " ") {
+			if len(tag) > 0 {
+				s := strings.Split(tag, "=")
+				if len(s) == 2 {
+					k, v := s[0], s[1]
+					if len(v) > 0 {
+						key, _ := url.QueryUnescape(k)
+						val, _ := url.QueryUnescape(v)
+						if len(key) > 0 && len(val) > 0 {
+							tags[key] = val
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 // ProviderHandler is an interface for dynamically adding and removing MetricSourceProviders

--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -22,8 +22,6 @@ package metrics
 
 import (
 	dto "github.com/prometheus/client_model/go"
-	"net/url"
-	"strings"
 	"time"
 )
 
@@ -186,7 +184,6 @@ type MetricPoint struct {
 	Labels []*dto.LabelPair
 
 	SrcTags map[string]string
-	StrTags string
 }
 
 func (m *MetricPoint) AddCustomTags(tags map[string]string) {
@@ -199,24 +196,6 @@ func (m *MetricPoint) AddCustomTags(tags map[string]string) {
 		k, v := label.GetName(), label.GetValue()
 		if len(k) > 0 && len(v) > 0 {
 			tags[k] = v
-		}
-	}
-
-	if len(m.StrTags) > 0 {
-		for _, tag := range strings.Split(m.StrTags, " ") {
-			if len(tag) > 0 {
-				s := strings.Split(tag, "=")
-				if len(s) == 2 {
-					k, v := s[0], s[1]
-					if len(v) > 0 {
-						key, _ := url.QueryUnescape(k)
-						val, _ := url.QueryUnescape(v)
-						if len(key) > 0 && len(val) > 0 {
-							tags[key] = val
-						}
-					}
-				}
-			}
 		}
 	}
 }

--- a/plugins/sinks/wavefront/wavefront.go
+++ b/plugins/sinks/wavefront/wavefront.go
@@ -6,7 +6,6 @@ package wavefront
 import (
 	"fmt"
 	"math/rand"
-	"net/url"
 	"os"
 	"runtime/debug"
 	"strconv"
@@ -154,24 +153,9 @@ func (sink *wavefrontSink) send(batch *metrics.DataBatch) {
 				tags[k] = v
 			}
 		}
+		// add label pairs, string encoded tags etc
+		point.AddCustomTags(tags)
 
-		if len(point.StrTags) > 0 {
-			for _, tag := range strings.Split(point.StrTags, " ") {
-				if len(tag) > 0 {
-					s := strings.Split(tag, "=")
-					if len(s) == 2 {
-						k, v := s[0], s[1]
-						if len(v) > 0 {
-							key, _ := url.QueryUnescape(k)
-							val, _ := url.QueryUnescape(v)
-							if len(key) > 0 && len(val) > 0 {
-								tags[key] = val
-							}
-						}
-					}
-				}
-			}
-		}
 		tags["cluster"] = sink.ClusterName
 		sink.sendPoint(point.Metric, point.Value, point.Timestamp, point.Source, tags)
 	}

--- a/plugins/sinks/wavefront/wavefront.go
+++ b/plugins/sinks/wavefront/wavefront.go
@@ -87,7 +87,9 @@ func (sink *wavefrontSink) sendPoint(metricName string, value float64, ts int64,
 	}
 	if sink.filters != nil && !sink.filters.Match(metricName, tags) {
 		filteredPoints.Inc(1)
-		log.WithField("name", metricName).Trace("Dropping metric")
+		if log.IsLevelEnabled(log.TraceLevel) {
+			log.WithField("name", metricName).Trace("Dropping metric")
+		}
 		return
 	}
 

--- a/plugins/sources/manager.go
+++ b/plugins/sources/manager.go
@@ -300,10 +300,8 @@ func appendProvider(slice []metrics.MetricsSourceProvider, provider metrics.Metr
 		return slice
 	}
 	slice = append(slice, provider)
-	if err == nil {
-		if i, ok := provider.(metrics.ConfigurabeMetricsSourceProvider); ok {
-			i.Configure(cfg.Interval, cfg.Timeout)
-		}
+	if i, ok := provider.(metrics.ConfigurabeMetricsSourceProvider); ok {
+		i.Configure(cfg.Interval, cfg.Timeout)
 	}
 	return slice
 }

--- a/plugins/sources/prometheus/prometheus.go
+++ b/plugins/sources/prometheus/prometheus.go
@@ -160,7 +160,7 @@ func (src *prometheusMetricsSource) parseMetrics(reader io.Reader) ([]*metrics.M
 	var parser expfmt.TextParser
 	metricFamilies, err := parser.TextToMetricFamilies(reader)
 	if err != nil {
-		return nil, fmt.Errorf("reading text format failed: %s", err)
+		log.Errorf("reading text format failed: %s", err)
 	}
 	return src.buildPoints(metricFamilies)
 }

--- a/plugins/sources/prometheus/prometheus.go
+++ b/plugins/sources/prometheus/prometheus.go
@@ -287,7 +287,9 @@ func (src *prometheusMetricsSource) isValidMetric(name string, tags map[string]s
 		return true
 	}
 	filteredPoints.Inc(1)
-	log.Tracef("dropping metric: %s", name)
+	if log.IsLevelEnabled(log.TraceLevel) {
+		log.Tracef("dropping metric: %s", name)
+	}
 	return false
 }
 

--- a/plugins/sources/prometheus/prometheus.go
+++ b/plugins/sources/prometheus/prometheus.go
@@ -239,7 +239,9 @@ func (src *prometheusMetricsSource) filterAppend(slice []*metrics.MetricPoint, p
 
 	if src.isValidMetric(point.Metric, point.Tags) {
 		if point.Tags == nil {
-			point.Tags = src.buildTags(m)
+			// skip allocating intermediate maps and pass label pairs and src tags directly to the sink
+			point.Labels = m.Label
+			point.SrcTags = src.tags
 		}
 		return append(slice, point)
 	}

--- a/plugins/sources/prometheus/prometheus_test.go
+++ b/plugins/sources/prometheus/prometheus_test.go
@@ -1,7 +1,6 @@
 package prometheus
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +23,7 @@ http_request_duration_seconds_count{label="good"} 3
 func TestNoFilters(t *testing.T) {
 	src := &prometheusMetricsSource{}
 
-	points, err := src.parseMetrics(strings.NewReader(metricsStr))
+	points, err := src.parseMetrics([]byte(metricsStr))
 	if err != nil {
 		assert.FailNow(t, err.Error())
 	}
@@ -41,7 +40,7 @@ func TestMetricWhitelist(t *testing.T) {
 		filters: f,
 	}
 
-	points, err := src.parseMetrics(strings.NewReader(metricsStr))
+	points, err := src.parseMetrics([]byte(metricsStr))
 	if err != nil {
 		assert.FailNow(t, err.Error())
 	}
@@ -58,7 +57,7 @@ func TestMetricBlacklist(t *testing.T) {
 		filters: f,
 	}
 
-	points, err := src.parseMetrics(strings.NewReader(metricsStr))
+	points, err := src.parseMetrics([]byte(metricsStr))
 	if err != nil {
 		assert.FailNow(t, err.Error())
 	}
@@ -75,7 +74,7 @@ func TestMetricTagWhitelist(t *testing.T) {
 		filters: f,
 	}
 
-	points, err := src.parseMetrics(strings.NewReader(metricsStr))
+	points, err := src.parseMetrics([]byte(metricsStr))
 	if err != nil {
 		assert.FailNow(t, err.Error())
 	}
@@ -92,7 +91,7 @@ func TestMetricTagBlacklist(t *testing.T) {
 		filters: f,
 	}
 
-	points, err := src.parseMetrics(strings.NewReader(metricsStr))
+	points, err := src.parseMetrics([]byte(metricsStr))
 	if err != nil {
 		assert.FailNow(t, err.Error())
 	}

--- a/plugins/sources/prometheus/prometheus_test.go
+++ b/plugins/sources/prometheus/prometheus_test.go
@@ -1,11 +1,13 @@
 package prometheus
 
 import (
-	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/filter"
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/metrics"
 )
 
 var metricsStr = `
@@ -20,15 +22,13 @@ http_request_duration_seconds_count{label="good"} 3
 `
 
 func TestNoFilters(t *testing.T) {
-	src := &prometheusMetricsSource{
-		buf: bytes.NewBufferString(""),
-	}
+	src := &prometheusMetricsSource{}
 
-	metrics, err := src.parseMetrics([]byte(metricsStr), nil)
+	points, err := src.parseMetrics(strings.NewReader(metricsStr))
 	if err != nil {
 		assert.FailNow(t, err.Error())
 	}
-	assert.Equal(t, 8, len(metrics), "wrong number of metrics")
+	assert.Equal(t, 8, len(points), "wrong number of points")
 }
 
 func TestMetricWhitelist(t *testing.T) {
@@ -38,15 +38,14 @@ func TestMetricWhitelist(t *testing.T) {
 	f := filter.NewGlobFilter(cfg)
 
 	src := &prometheusMetricsSource{
-		buf:     bytes.NewBufferString(""),
 		filters: f,
 	}
 
-	metrics, err := src.parseMetrics([]byte(metricsStr), nil)
+	points, err := src.parseMetrics(strings.NewReader(metricsStr))
 	if err != nil {
 		assert.FailNow(t, err.Error())
 	}
-	assert.Equal(t, 1, len(metrics), "wrong number of metrics")
+	assert.Equal(t, 1, len(points), "wrong number of points")
 }
 
 func TestMetricBlacklist(t *testing.T) {
@@ -56,15 +55,14 @@ func TestMetricBlacklist(t *testing.T) {
 	f := filter.NewGlobFilter(cfg)
 
 	src := &prometheusMetricsSource{
-		buf:     bytes.NewBufferString(""),
 		filters: f,
 	}
 
-	metrics, err := src.parseMetrics([]byte(metricsStr), nil)
+	points, err := src.parseMetrics(strings.NewReader(metricsStr))
 	if err != nil {
 		assert.FailNow(t, err.Error())
 	}
-	assert.Equal(t, 7, len(metrics), "wrong number of metrics")
+	assert.Equal(t, 7, len(points), "wrong number of points")
 }
 
 func TestMetricTagWhitelist(t *testing.T) {
@@ -74,15 +72,14 @@ func TestMetricTagWhitelist(t *testing.T) {
 	f := filter.NewGlobFilter(cfg)
 
 	src := &prometheusMetricsSource{
-		buf:     bytes.NewBufferString(""),
 		filters: f,
 	}
 
-	metrics, err := src.parseMetrics([]byte(metricsStr), nil)
+	points, err := src.parseMetrics(strings.NewReader(metricsStr))
 	if err != nil {
 		assert.FailNow(t, err.Error())
 	}
-	assert.Equal(t, 1, len(metrics), "wrong number of metrics")
+	assert.Equal(t, 1, len(points), "wrong number of points")
 }
 
 func TestMetricTagBlacklist(t *testing.T) {
@@ -92,13 +89,24 @@ func TestMetricTagBlacklist(t *testing.T) {
 	f := filter.NewGlobFilter(cfg)
 
 	src := &prometheusMetricsSource{
-		buf:     bytes.NewBufferString(""),
 		filters: f,
 	}
 
-	metrics, err := src.parseMetrics([]byte(metricsStr), nil)
+	points, err := src.parseMetrics(strings.NewReader(metricsStr))
 	if err != nil {
 		assert.FailNow(t, err.Error())
 	}
-	assert.Equal(t, 7, len(metrics), "wrong number of metrics")
+	assert.Equal(t, 7, len(points), "wrong number of points")
+}
+
+var tempTags = map[string]string{"pod_name": "prometheus_pod_xyz", "namespace_name": "default"}
+var result *metrics.MetricPoint
+
+func BenchmarkMetricPoint(b *testing.B) {
+	src := &prometheusMetricsSource{prefix: "prefix."}
+	var r *metrics.MetricPoint
+	for i := 0; i < b.N; i++ {
+		r = src.metricPoint("http.requests.total.count", 1.0, 0, "", tempTags)
+	}
+	result = r
 }

--- a/plugins/sources/summary/wavefront_converter.go
+++ b/plugins/sources/summary/wavefront_converter.go
@@ -141,7 +141,9 @@ func (converter *pointConverter) filterAppend(slice []*metrics.MetricPoint, poin
 		return append(slice, point)
 	}
 	converter.filteredPoints.Inc(1)
-	log.WithField("name", point.Metric).Trace("Dropping metric")
+	if log.IsLevelEnabled(log.TraceLevel) {
+		log.WithField("name", point.Metric).Trace("Dropping metric")
+	}
 	return slice
 }
 


### PR DESCRIPTION
Collector instance was OOM killed when collecting data from very large prometheus endpoints (exposing ~1M points). A fair chunk of heap is allocated by the prometheus text parser when parsing the response body. That has not been optimized as part of this PR.

Optimizations addressed in this PR:
- Changed to not read entire response body into memory (ioutil.ReadAll over allocates memory). Instead use a pre-allocated buffer (this allocates memory equal to the response content length).
- Avoid tag creation when only metric name based filtering is enabled at the prometheus source level
- Pass through prometheus labels to sink when possible (avoiding creating additional maps altogether)

Also modified high volume trace/debug level logging to check whether level is enabled before logging.

Memory usage patterns may vary based on cpu limits enforced on the container (Impacting GC performance). 