### PR TITLE
rename whitelist/blacklist to allow/deny-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ Refer to the [installation instructions](https://docs.wavefront.com/kubernetes.h
 
 The installation instructions use a default configuration suitable for most use cases. Refer to the [documentation](https://github.com/wavefrontHQ/wavefront-kubernetes-collector/tree/master/docs) for details on all the configuration options.
 
-## OpenShift
-This collector supports monitoring of Openshift Origin 3.9 clusters. See [openshift.md](https://github.com/wavefronthq/wavefront-kubernetes-collector/tree/master/docs/openshift.md) for detailed installation instructions.
-
 ## Contributing
 Public contributions are always welcome. Please feel free to report issues or submit pull requests.
 

--- a/deploy/examples/conf.example.yaml
+++ b/deploy/examples/conf.example.yaml
@@ -19,7 +19,7 @@ data:
 
       filters:
         # Filter out infrequently used kube-state-metrics.
-        metricBlacklist:
+        metricDenyList:
         - 'kube.configmap.annotations.gauge'
         - 'kube.configmap.metadata.resource.version.gauge'
         - 'kube.endpoint.*'
@@ -67,7 +67,7 @@ data:
         prefix: 'kubernetes.'
 
         filters:
-          metricBlacklist:
+          metricDenylist:
           - 'kubernetes.sys_container.*'
 
       internal_stats_source:
@@ -100,7 +100,7 @@ data:
         prefix: 'kube.apiserver.'
 
         filters:
-          metricWhitelist:
+          metricAllowList:
           - 'kube.apiserver.apiserver.*'
           - 'kube.apiserver.etcd.*'
           - 'kube.apiserver.process.*'
@@ -317,7 +317,7 @@ data:
         scheme: http
         prefix: kube.dns.
         filters:
-          metricWhitelist:
+          metricAllowList:
           - 'kube.dns.http.request.duration.microseconds'
           - 'kube.dns.http.request.size.bytes'
           - 'kube.dns.http.requests.total.counter'
@@ -339,7 +339,7 @@ data:
         scheme: http
         prefix: kube.coredns.
         filters:
-          metricWhitelist:
+          metricAllowList:
           - 'kube.coredns.coredns.cache.*'
           - 'kube.coredns.coredns.dns.request.count.total.counter'
           - 'kube.coredns.coredns.dns.request.duration.seconds'

--- a/deploy/kubernetes/4-collector-config.yaml
+++ b/deploy/kubernetes/4-collector-config.yaml
@@ -13,7 +13,7 @@ data:
     # sample configuration to filter events
     # events:
     #   filters:
-    #     tagWhitelistSets:
+    #     tagAllowListSets:
     #     - kind:
     #       - "Pod"
     #       reason:
@@ -42,7 +42,7 @@ data:
         prefix: 'kubernetes.'
 
         filters:
-          metricBlacklist:
+          metricDenyList:
           - 'kubernetes.sys_container.*'
 
       internal_stats_source:
@@ -68,7 +68,7 @@ data:
       #   prefix: 'kube.apiserver.'
       #
       #   filters:
-      #     metricWhitelist:
+      #     metricAllowList:
       #     - 'kube.apiserver.apiserver.*'
       #     - 'kube.apiserver.etcd.*'
       #     - 'kube.apiserver.process.*'
@@ -285,7 +285,7 @@ data:
         scheme: http
         prefix: kube.dns.
         filters:
-          metricWhitelist:
+          metricAllowList:
           - 'kube.dns.http.request.duration.microseconds'
           - 'kube.dns.http.request.size.bytes'
           - 'kube.dns.http.requests.total.counter'
@@ -307,7 +307,7 @@ data:
         scheme: http
         prefix: kube.coredns.
         filters:
-          metricWhitelist:
+          metricAllowList:
           - 'kube.coredns.coredns.cache.*'
           - 'kube.coredns.coredns.dns.request.count.total.counter'
           - 'kube.coredns.coredns.dns.request.duration.seconds'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,12 +189,12 @@ startTimeMetrics: <true|false>
 restartMetrics: <true|false>
 
 # List of glob patterns. Metrics from matching systemd unit names are reported.
-unitWhitelist:
+unitAllowList:
 - 'docker*'
 - 'kubelet*'
 
 # List of glob patterns. Metrics from matching systemd unit names are not reported.
-unitBlacklist:
+unitDenyList:
 - '*mount*'
 - 'etc*'
 ```
@@ -214,23 +214,23 @@ tags:
 
 # Filters to be applied to metrics collected by a source or reported by sinks.
 filters:
-  # List of glob patterns. Only metrics with names matching the whitelist are reported.
-  metricWhitelist:
+  # List of glob patterns. Only metrics with names matching the list are reported.
+  metricAllowList:
   - 'kube.dns.http.*'
   - 'kube.dns.process.*'
 
-  # List of glob patterns. Metrics with names matching the blacklist are dropped.
-  metricBlacklist:
+  # List of glob patterns. Metrics with names matching the list are dropped.
+  metricDenyList:
   - 'kube.dns.go.*'
 
-  # Map of tag names to list of glob patterns. Only metrics containing tag keys and values matching the whitelist will be reported.
-  metricTagWhitelist:
+  # Map of tag names to list of glob patterns. Only metrics containing tag keys and values matching the list will be reported.
+  metricTagAllowList:
     env:
     - 'prod*'
     - 'staging*'
 
-  # Map of tag names to list of glob patterns. Metrics containing blacklisted tag keys and values will be dropped.
-  metricTagBlacklist:
+  # Map of tag names to list of glob patterns. Metrics containing these tag keys and values will be dropped.
+  metricTagDenyList:
     env:
     - 'test*'
 

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -12,10 +12,10 @@ The Wavefront Collector supports filtering metrics and events. Filters are based
 
 The Wavefront Collector for Kubernetes supports filtering metrics before they are reported to Wavefront. The following filtering options are supported for metrics:
 
-  * **metricWhitelist**: List of glob patterns. Only metrics with names matching the whitelist are reported.
-  * **metricBlacklist**: List of glob patterns. Metrics with names matching the blacklist are dropped.
-  * **metricTagWhitelist**: Map of tag names to list of glob patterns. Only metrics containing tag keys and values matching the whitelist will be reported.
-  * **metricTagBlacklist**: Map of tag names to list of glob patterns. Metrics containing blacklisted tag keys and values will be dropped.
+  * **metricAllowList**: List of glob patterns. Only metrics with names matching this list are reported.
+  * **metricDenyList**: List of glob patterns. Metrics with names matching this list are dropped.
+  * **metricTagAllowList**: Map of tag names to list of glob patterns. Only metrics containing tag keys and values matching this list will be reported.
+  * **metricTagDenyList**: Map of tag names to list of glob patterns. Metrics containing these tag keys and values will be dropped.
   * **tagInclude**: List of glob patterns. Tags with matching keys will be included. All other tags will be excluded.
   * **tagExclude**: List of glob patterns. Tags with matching keys will be excluded.
 
@@ -30,18 +30,18 @@ sinks:
   # global sink level filter
   filters:
     # Filter out all go runtime metrics for kube-dns and apiserver.
-    metricBlacklist:
+    metricDenyList:
     - 'kube.dns.go.*'
     - 'kube.apiserver.go.*'
 
-    # Whitelist metrics that have an environment tag of production or staging
-    metricTagWhitelist:
+    # Allow metrics that have an environment tag of production or staging
+    metricTagAllowList:
       env:
       - 'prod*'
       - 'staging*'
 
-    # Blacklist metrics that have an environment tag of test.
-    metricTagBlacklist:
+    # Block metrics that have an environment tag of test.
+    metricTagDenyList:
       env:
       - 'test*'
 ```
@@ -55,17 +55,17 @@ prometheus_sources:
 
     filters:
       # Filter out all go runtime metrics
-      metricBlacklist:
+      metricDenyList:
       - 'prom.app.go.*'
 
-      # Whitelist metrics that have an environment tag of production or staging
-      metricTagWhitelist:
+      # Allow metrics that have an environment tag of production or staging
+      metricTagAllowList:
         env:
         - 'prod*'
         - 'staging*'
 
-      # Blacklist metrics that have an environment tag of test.
-      metricTagBlacklist:
+      # Block metrics that have an environment tag of test.
+      metricTagDenyList:
         env:
         - 'test*'
 ```
@@ -81,11 +81,11 @@ discovery_configs:
 
     # filtering rules to be applied towards kube-dns metrics
     filters:
-      metricBlacklist:
+      metricDenyList:
       - 'kube.dns.go.*'
       - 'kube.dns.probe.*'
 
-      metricTagWhitelist:
+      metricTagAllowList:
         env:
         - 'prod1*'
         - 'prod2*'
@@ -98,17 +98,17 @@ discovery_configs:
 
 The Wavefront Collector for Kubernetes also supports filtering events before they are reported to Wavefront. The following filtering options are supported for events:
 
-* **tagWhitelist**: Map of tag names to list of glob patterns. Only events containing tag keys and values matching the whitelist will be reported.
-* **tagBlacklist**: Map of tag names to list of glob patterns. Events containing blacklisted tag keys and values will be dropped.
-* **tagWhitelistSets**: List of maps of tag names to list of glob patterns. Filters within each map are AND'd. Filters between the maps are OR'd.
-* **tagBlacklistSets**: List of maps of tag names to list of glob patterns. Filters within each map are AND'd. Filters between the maps are OR'd.
+* **tagAllowList**: Map of tag names to list of glob patterns. Only events containing tag keys and values matching the list will be reported.
+* **tagDenyList**: Map of tag names to list of glob patterns. Events containing these tag keys and values will be dropped.
+* **tagAllowListSets**: List of maps of tag names to list of glob patterns. Filters within each map are AND'd. Filters between the maps are OR'd.
+* **tagDenyListSets**: List of maps of tag names to list of glob patterns. Filters within each map are AND'd. Filters between the maps are OR'd.
 
-Event filtering is specified within the top level events section in the config. For example to whitelist either Pod or DaemonSet events with a specific reason:
+Event filtering is specified within the top level events section in the config. For example to allow either Pod or DaemonSet events with a specific reason:
 
 ```yaml
 events:
   filters:
-    tagWhitelistSets:
+    tagAllowListSets:
     - kind:
      - "Pod"
      reason:

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -56,9 +56,18 @@ type EventsConfig struct {
 }
 
 type EventsFilter struct {
-	TagWhitelist     map[string][]string   `yaml:"tagWhitelist"`
-	TagBlacklist     map[string][]string   `yaml:"tagBlacklist"`
+	TagAllowList     map[string][]string   `yaml:"tagAllowList"`
+	TagDenyList      map[string][]string   `yaml:"tagDenyList"`
+	TagAllowListSets []map[string][]string `yaml:"tagAllowListSets"`
+	TagDenyListSets  []map[string][]string `yaml:"tagDenyListSets"`
+
+	// Deprecated: Use TagAllowList
+	TagWhitelist map[string][]string `yaml:"tagWhitelist"`
+	// Deprecated: Use TagDenyList
+	TagBlacklist map[string][]string `yaml:"tagBlacklist"`
+	// Deprecated: Use TagAllowListSets
 	TagWhitelistSets []map[string][]string `yaml:"tagWhitelistSets"`
+	// Deprecated: Use TagDenyListSets
 	TagBlacklistSets []map[string][]string `yaml:"tagBlacklistSets"`
 }
 
@@ -209,9 +218,9 @@ type SystemdSourceConfig struct {
 
 	IncludeRestartMetrics bool `yaml:"restartMetrics"`
 
-	UnitWhitelist []string `yaml:"unitWhitelist"`
+	UnitAllowList []string `yaml:"unitAllowList"`
 
-	UnitBlacklist []string `yaml:"unitBlacklist"`
+	UnitDenyList []string `yaml:"unitDenyList"`
 }
 
 type StatsSourceConfig struct {

--- a/internal/configuration/parser_test.go
+++ b/internal/configuration/parser_test.go
@@ -22,10 +22,10 @@ sinks:
     env: gcp-dev
     image: 0.9.9-rc3
   filters:
-    metricWhitelist:
+    metricAllowList:
     - 'kubernetes.node.*'
 
-    metricTagWhitelist:
+    metricTagAllowList:
       nodename:
       - 'gke-vikramr-cluster*wj2d'
 
@@ -34,12 +34,12 @@ sinks:
 
 events:
   filters:
-    tagWhitelist:
+    tagAllowList:
       namespace:
       - "default"
       component:
       - "pp"
-    tagWhitelistSets:
+    tagAllowListSets:
     - kind:
       - "Pod"
       reason:
@@ -96,8 +96,8 @@ func TestFromYAML(t *testing.T) {
 	}
 
 	assert.True(t, cfg.EnableEvents)
-	assert.Equal(t, "default", cfg.EventsConfig.Filters.TagWhitelist["namespace"][0])
-	assert.Equal(t, "pp", cfg.EventsConfig.Filters.TagWhitelist["component"][0])
+	assert.Equal(t, "default", cfg.EventsConfig.Filters.TagAllowList["namespace"][0])
+	assert.Equal(t, "pp", cfg.EventsConfig.Filters.TagAllowList["component"][0])
 
 	assert.True(t, len(cfg.Sources.PrometheusConfigs) > 0)
 	assert.Equal(t, "kubernetes.", cfg.Sources.SummaryConfig.Prefix)

--- a/internal/discovery/parser_test.go
+++ b/internal/discovery/parser_test.go
@@ -43,13 +43,13 @@ plugins:
     tags:
       env: prod
     filters:
-      metricWhitelist:
+      metricAllowList:
       - '*foo*'
       - 'bar*'
-      metricBlacklist:
+      metricDenyList:
       - 'kube.dns.go.*'
       - 'kube.dns.probe.*'
-      metricTagWhitelist:
+      metricTagAllowList:
         env:
         - 'prod1*'
         - 'prod2*'
@@ -67,13 +67,13 @@ func TestFromYAML(t *testing.T) {
 	if len(cfg.PluginConfigs) != 3 {
 		t.Errorf("invalid number of plugins")
 	}
-	if len(cfg.PluginConfigs[2].Filters.MetricWhitelist) != 2 {
+	if len(cfg.PluginConfigs[2].Filters.MetricAllowList) != 2 {
 		t.Errorf("error parsing filters")
 	}
-	if len(cfg.PluginConfigs[2].Filters.MetricBlacklist) != 2 {
+	if len(cfg.PluginConfigs[2].Filters.MetricDenyList) != 2 {
 		t.Errorf("error parsing filters")
 	}
-	if len(cfg.PluginConfigs[2].Filters.MetricTagWhitelist) != 2 {
+	if len(cfg.PluginConfigs[2].Filters.MetricTagAllowList) != 2 {
 		t.Errorf("error parsing filters")
 	}
 	if len(cfg.PluginConfigs[0].Selectors.Images) != 2 {

--- a/internal/filter/config.go
+++ b/internal/filter/config.go
@@ -15,26 +15,41 @@ const (
 // Configuration for filtering metrics.
 // All the filtering options are applied at the end after specified prefixes etc are applied.
 type Config struct {
-	// List of glob pattern strings. Only metrics with names matching the whitelist are reported.
-	MetricWhitelist []string `yaml:"metricWhitelist"`
+	// List of glob pattern strings. Only metrics with names matching this list are reported.
+	MetricAllowList []string `yaml:"metricAllowList"`
 
-	// List of glob pattern strings. Metrics with names matching the blacklist are dropped.
-	MetricBlacklist []string `yaml:"metricBlacklist"`
+	// List of glob pattern strings. Metrics with names matching this list are dropped.
+	MetricDenyList []string `yaml:"metricDenyList"`
 
-	// List of glob pattern strings. Only metrics containing tag keys matching the whitelist will be reported.
-	MetricTagWhitelist map[string][]string `yaml:"metricTagWhitelist"`
+	// List of glob pattern strings. Only metrics containing tag keys matching the list will be reported.
+	MetricTagAllowList map[string][]string `yaml:"metricTagAllowList"`
 
-	// List of glob pattern strings. Metrics containing blacklisted tag keys will be dropped.
-	MetricTagBlacklist map[string][]string `yaml:"metricTagBlacklist"`
+	// List of glob pattern strings. Metrics containing these tag keys will be dropped.
+	MetricTagDenyList map[string][]string `yaml:"metricTagDenyList"`
 
 	// List of glob pattern strings. Tags with matching keys will be included. All other tags will be excluded.
 	TagInclude []string `yaml:"tagInclude"`
 
 	// List of glob pattern strings. Tags with matching keys will be excluded.
 	TagExclude []string `yaml:"tagExclude"`
+
+	// Deprecated: use MetricAllowList instead
+	MetricWhitelist []string `yaml:"metricWhitelist"`
+
+	// Deprecated: use MetricDenyList instead
+	MetricBlacklist []string `yaml:"metricBlacklist"`
+
+	// Deprecated: use MetricTagAllowList instead
+	MetricTagWhitelist map[string][]string `yaml:"metricTagWhitelist"`
+
+	// Deprecated: use MetricTagDenyList instead
+	MetricTagBlacklist map[string][]string `yaml:"metricTagBlacklist"`
 }
 
 func (cfg Config) Empty() bool {
-	return len(cfg.MetricWhitelist) == 0 && len(cfg.MetricBlacklist) == 0 && len(cfg.MetricTagWhitelist) == 0 &&
-		len(cfg.MetricTagBlacklist) == 0 && len(cfg.TagInclude) == 0 && len(cfg.TagExclude) == 0
+	return len(cfg.MetricWhitelist) == 0 && len(cfg.MetricAllowList) == 0 &&
+		len(cfg.MetricBlacklist) == 0 && len(cfg.MetricDenyList) == 0 &&
+		len(cfg.MetricTagWhitelist) == 0 && len(cfg.MetricTagAllowList) == 0 &&
+		len(cfg.MetricTagBlacklist) == 0 && len(cfg.MetricTagDenyList) == 0 &&
+		len(cfg.TagInclude) == 0 && len(cfg.TagExclude) == 0
 }

--- a/internal/filter/glob_test.go
+++ b/internal/filter/glob_test.go
@@ -94,9 +94,9 @@ func TestDeleteTags(t *testing.T) {
 	}
 }
 
-func TestMetricWhitelist(t *testing.T) {
+func TestMetricAllowList(t *testing.T) {
 	cfg := Config{
-		MetricWhitelist: []string{"foo"},
+		MetricAllowList: []string{"foo"},
 	}
 	f := NewGlobFilter(cfg)
 
@@ -110,16 +110,16 @@ func TestMetricWhitelist(t *testing.T) {
 		t.Errorf("name pass error")
 	}
 
-	cfg.MetricWhitelist = []string{"foo*"}
+	cfg.MetricAllowList = []string{"foo*"}
 	f = NewGlobFilter(cfg)
 	if !f.Match(pt.Metric, pt.Tags) {
 		t.Errorf("name pass error")
 	}
 }
 
-func TestMetricBlacklist(t *testing.T) {
+func TestMetricDenyList(t *testing.T) {
 	cfg := Config{
-		MetricBlacklist: []string{"foo"},
+		MetricDenyList: []string{"foo"},
 	}
 	f := NewGlobFilter(cfg)
 	pt := point("foobar", 1.0, 0, "", nil)
@@ -127,16 +127,16 @@ func TestMetricBlacklist(t *testing.T) {
 		t.Errorf("name drop error")
 	}
 
-	cfg.MetricBlacklist = []string{"foo*"}
+	cfg.MetricDenyList = []string{"foo*"}
 	f = NewGlobFilter(cfg)
 	if f.Match(pt.Metric, pt.Tags) {
 		t.Errorf("name drop error")
 	}
 }
 
-func TestMetricTagWhitelist(t *testing.T) {
+func TestMetricTagAllowList(t *testing.T) {
 	cfg := Config{
-		MetricTagWhitelist: map[string][]string{
+		MetricTagAllowList: map[string][]string{
 			"foo": {"va*"},
 		},
 	}
@@ -152,9 +152,9 @@ func TestMetricTagWhitelist(t *testing.T) {
 	}
 }
 
-func TestMetricTagBlacklist(t *testing.T) {
+func TestMetricTagDenyList(t *testing.T) {
 	cfg := Config{
-		MetricTagBlacklist: map[string][]string{
+		MetricTagDenyList: map[string][]string{
 			"foo": {"va*"},
 		},
 	}

--- a/internal/filter/util.go
+++ b/internal/filter/util.go
@@ -13,6 +13,10 @@ func FromQuery(vals map[string][]string) Config {
 		return Config{}
 	}
 
+	// this is legacy code retained for backwards compat when using CLI flags (instead of config file)
+	// newer terminology (allow/deny) has not been back ported for now. This function and associated calls
+	// can just be deleted once we choose to stop supporting the older CLI flags method for good.
+
 	metricWhitelist := vals[MetricWhitelist]
 	metricBlacklist := vals[MetricBlacklist]
 	metricTagWhitelist := parseFilters(vals[MetricTagWhitelist])
@@ -40,23 +44,35 @@ func FromConfig(cfg Config) Filter {
 		return nil
 	}
 
-	metricWhitelist := cfg.MetricWhitelist
-	metricBlacklist := cfg.MetricBlacklist
-	metricTagWhitelist := cfg.MetricTagWhitelist
-	metricTagBlacklist := cfg.MetricTagBlacklist
+	metricAllowList := cfg.MetricWhitelist
+	if len(cfg.MetricAllowList) > 0 {
+		metricAllowList = cfg.MetricAllowList
+	}
+	metricDenyList := cfg.MetricBlacklist
+	if len(cfg.MetricDenyList) > 0 {
+		metricDenyList = cfg.MetricDenyList
+	}
+	metricTagAllowList := cfg.MetricTagWhitelist
+	if len(cfg.MetricTagAllowList) > 0 {
+		metricTagAllowList = cfg.MetricTagAllowList
+	}
+	metricTagDenyList := cfg.MetricTagBlacklist
+	if len(cfg.MetricTagDenyList) > 0 {
+		metricTagDenyList = cfg.MetricTagDenyList
+	}
 	tagInclude := cfg.TagInclude
 	tagExclude := cfg.TagExclude
 
-	if len(metricWhitelist) == 0 && len(metricBlacklist) == 0 && len(metricTagWhitelist) == 0 &&
-		len(metricTagBlacklist) == 0 && len(tagInclude) == 0 && len(tagExclude) == 0 {
+	if len(metricAllowList) == 0 && len(metricDenyList) == 0 && len(metricTagAllowList) == 0 &&
+		len(metricTagDenyList) == 0 && len(tagInclude) == 0 && len(tagExclude) == 0 {
 		return nil
 	}
 
 	return NewGlobFilter(Config{
-		MetricWhitelist:    metricWhitelist,
-		MetricBlacklist:    metricBlacklist,
-		MetricTagWhitelist: metricTagWhitelist,
-		MetricTagBlacklist: metricTagBlacklist,
+		MetricAllowList:    metricAllowList,
+		MetricDenyList:     metricDenyList,
+		MetricTagAllowList: metricTagAllowList,
+		MetricTagDenyList:  metricTagDenyList,
 		TagInclude:         tagInclude,
 		TagExclude:         tagExclude,
 	})

--- a/internal/filter/util_test.go
+++ b/internal/filter/util_test.go
@@ -13,6 +13,7 @@ func TestFromConfig(t *testing.T) {
 	f := FromConfig(Config{})
 	assert.Equal(t, nil, f)
 
+	// verify previous fields still work for backwards compat
 	f = FromConfig(Config{
 		MetricWhitelist:    []string{"foo*", "bar*"},
 		MetricTagBlacklist: map[string][]string{"env": {"dev*", "test*"}},
@@ -20,9 +21,27 @@ func TestFromConfig(t *testing.T) {
 
 	gf, ok := f.(*globFilter)
 	assert.True(t, ok)
+	assert.NotNil(t, gf.metricAllowList)
+	assert.NotNil(t, gf.metricTagDenyList)
+	assert.Nil(t, gf.metricDenyList)
+	assert.Nil(t, gf.metricTagAllowList)
+	assert.Nil(t, gf.tagInclude)
+	assert.Nil(t, gf.tagExclude)
 
-	assert.Nil(t, gf.metricBlacklist)
-	assert.Nil(t, gf.metricTagWhitelist)
+	// verify new fields work
+	f = FromConfig(Config{
+		MetricAllowList:    []string{"foo*", "bar*"},
+		MetricDenyList:     []string{"foo*", "bar*"},
+		MetricTagAllowList: map[string][]string{"env": {"dev*", "test*"}},
+		MetricTagDenyList:  map[string][]string{"env": {"dev*", "test*"}},
+	})
+
+	gf, ok = f.(*globFilter)
+	assert.True(t, ok)
+	assert.NotNil(t, gf.metricAllowList)
+	assert.NotNil(t, gf.metricDenyList)
+	assert.NotNil(t, gf.metricTagAllowList)
+	assert.NotNil(t, gf.metricTagDenyList)
 	assert.Nil(t, gf.tagInclude)
 	assert.Nil(t, gf.tagExclude)
 }
@@ -51,8 +70,8 @@ func TestFromQuery(t *testing.T) {
 		t.Errorf("error creating filter")
 	}
 
-	if gf.metricWhitelist == nil || gf.metricBlacklist == nil || gf.metricTagWhitelist == nil ||
-		gf.metricTagBlacklist == nil || gf.tagInclude == nil || gf.tagExclude == nil {
+	if gf.metricAllowList == nil || gf.metricDenyList == nil || gf.metricTagAllowList == nil ||
+		gf.metricTagDenyList == nil || gf.tagInclude == nil || gf.tagExclude == nil {
 		t.Errorf("error creating filter")
 	}
 }

--- a/internal/options/adapter.go
+++ b/internal/options/adapter.go
@@ -153,8 +153,8 @@ func addSystemdSource(cfg *configuration.Config, uri flags.Uri) {
 		IncludeTaskMetrics:      flags.DecodeBoolean(vals, "taskMetrics"),
 		IncludeRestartMetrics:   flags.DecodeBoolean(vals, "restartMetrics"),
 		IncludeStartTimeMetrics: flags.DecodeBoolean(vals, "startTimeMetrics"),
-		UnitWhitelist:           vals["unitWhitelist"],
-		UnitBlacklist:           vals["unitBlacklist"],
+		UnitAllowList:           vals["unitWhitelist"],
+		UnitDenyList:            vals["unitBlacklist"],
 		Transforms:              getTransforms(vals),
 	}
 	cfg.Sources.SystemdConfig = systemd

--- a/plugins/discovery/config_test.go
+++ b/plugins/discovery/config_test.go
@@ -46,13 +46,13 @@ plugins:
     tags:
       env: prod
     filters:
-      metricWhitelist:
+      metricAllowList:
       - '*foo*'
       - 'bar*'
-      metricBlacklist:
+      metricDenyList:
       - 'kube.dns.go.*'
       - 'kube.dns.probe.*'
-      metricTagWhitelist:
+      metricTagAllowList:
         env:
         - 'prod1*'
         - 'prod2*'

--- a/plugins/events/filter.go
+++ b/plugins/events/filter.go
@@ -10,41 +10,58 @@ import (
 )
 
 type eventFilter struct {
-	whitelist     map[string]glob.Glob
-	blacklist     map[string]glob.Glob
-	whitelistSets []map[string]glob.Glob
-	blacklistSets []map[string]glob.Glob
+	allowList     map[string]glob.Glob
+	denyList      map[string]glob.Glob
+	allowListSets []map[string]glob.Glob
+	denyListSets  []map[string]glob.Glob
 }
 
 func newEventFilter(filters configuration.EventsFilter) eventFilter {
+	allowList := filters.TagWhitelist
+	if len(filters.TagAllowList) > 0 {
+		allowList = filters.TagAllowList
+	}
+	denyList := filters.TagBlacklist
+	if len(filters.TagDenyList) > 0 {
+		denyList = filters.TagDenyList
+	}
+	allowListSets := filters.TagWhitelistSets
+	if len(filters.TagAllowListSets) > 0 {
+		allowListSets = filters.TagAllowListSets
+	}
+	denyListSets := filters.TagBlacklistSets
+	if len(filters.TagDenyListSets) > 0 {
+		denyListSets = filters.TagDenyListSets
+	}
+
 	return eventFilter{
-		whitelist:     filter.MultiCompile(filters.TagWhitelist),
-		blacklist:     filter.MultiCompile(filters.TagBlacklist),
-		whitelistSets: filter.MultiSetCompile(filters.TagWhitelistSets),
-		blacklistSets: filter.MultiSetCompile(filters.TagBlacklistSets),
+		allowList:     filter.MultiCompile(allowList),
+		denyList:      filter.MultiCompile(denyList),
+		allowListSets: filter.MultiSetCompile(allowListSets),
+		denyListSets:  filter.MultiSetCompile(denyListSets),
 	}
 }
 
 func (ef eventFilter) matches(tags map[string]string) bool {
-	if len(ef.whitelist) > 0 && !filter.MatchesTags(ef.whitelist, tags) {
+	if len(ef.allowList) > 0 && !filter.MatchesTags(ef.allowList, tags) {
 		return false
 	}
-	if len(ef.blacklist) > 0 && filter.MatchesTags(ef.blacklist, tags) {
+	if len(ef.denyList) > 0 && filter.MatchesTags(ef.denyList, tags) {
 		return false
 	}
 
-	if len(ef.whitelistSets) > 0 {
+	if len(ef.allowListSets) > 0 {
 		// AND tags within a set, OR between sets
-		for _, wl := range ef.whitelistSets {
+		for _, wl := range ef.allowListSets {
 			if filter.MatchesAllTags(wl, tags) {
 				return true
 			}
 		}
 		return false
 	}
-	if len(ef.blacklistSets) > 0 {
+	if len(ef.denyListSets) > 0 {
 		// AND tags within a set, OR between sets
-		for _, bl := range ef.blacklistSets {
+		for _, bl := range ef.denyListSets {
 			if filter.MatchesAllTags(bl, tags) {
 				return false
 			}

--- a/plugins/events/filter_test.go
+++ b/plugins/events/filter_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/configuration"
 )
 
-func TestWhitelist(t *testing.T) {
+func TestAllowList(t *testing.T) {
+	// test the previous field for backwards compat
 	ef := newEventFilter(configuration.EventsFilter{
 		TagWhitelist: map[string][]string{"foo": {"bar"}},
 	})
@@ -18,9 +19,20 @@ func TestWhitelist(t *testing.T) {
 	if !ef.matches(map[string]string{"foo": "bar"}) {
 		t.Errorf("error matching event tags")
 	}
+
+	ef = newEventFilter(configuration.EventsFilter{
+		TagAllowList: map[string][]string{"foo": {"bar"}},
+	})
+	if ef.matches(map[string]string{"k": "v", "foo": "bard"}) {
+		t.Errorf("error matching event tags")
+	}
+	if !ef.matches(map[string]string{"foo": "bar"}) {
+		t.Errorf("error matching event tags")
+	}
 }
 
-func TestBlacklist(t *testing.T) {
+func TestDenyList(t *testing.T) {
+	// test the previous field for backwards compat
 	ef := newEventFilter(configuration.EventsFilter{
 		TagBlacklist: map[string][]string{"foo": {"bar"}},
 	})
@@ -30,9 +42,20 @@ func TestBlacklist(t *testing.T) {
 	if ef.matches(map[string]string{"foo": "bar"}) {
 		t.Errorf("error matching event tags")
 	}
+
+	ef = newEventFilter(configuration.EventsFilter{
+		TagDenyList: map[string][]string{"foo": {"bar"}},
+	})
+	if !ef.matches(map[string]string{"k": "v", "foo": "bard"}) {
+		t.Errorf("error matching event tags")
+	}
+	if ef.matches(map[string]string{"foo": "bar"}) {
+		t.Errorf("error matching event tags")
+	}
 }
 
-func TestWhitelistSets(t *testing.T) {
+func TestAllowListSets(t *testing.T) {
+	// test previous field for backwards compat
 	ef := newEventFilter(configuration.EventsFilter{
 		TagWhitelistSets: []map[string][]string{
 			{
@@ -47,11 +70,42 @@ func TestWhitelistSets(t *testing.T) {
 	if !ef.matches(map[string]string{"foo": "bar", "food": "bard"}) {
 		t.Errorf("error matching event tags")
 	}
+
+	ef = newEventFilter(configuration.EventsFilter{
+		TagAllowListSets: []map[string][]string{
+			{
+				"foo":  {"bar"},
+				"food": {"bard"},
+			},
+		},
+	})
+	if ef.matches(map[string]string{"foo": "bar"}) {
+		t.Errorf("error matching event tags")
+	}
+	if !ef.matches(map[string]string{"foo": "bar", "food": "bard"}) {
+		t.Errorf("error matching event tags")
+	}
 }
 
-func TestBlacklistSets(t *testing.T) {
+func TestDenyListSets(t *testing.T) {
+	// test previous field for backwards compat
 	ef := newEventFilter(configuration.EventsFilter{
 		TagBlacklistSets: []map[string][]string{
+			{
+				"foo":  {"bar"},
+				"food": {"bard"},
+			},
+		},
+	})
+	if !ef.matches(map[string]string{"foo": "bar"}) {
+		t.Errorf("error matching event tags")
+	}
+	if ef.matches(map[string]string{"foo": "bar", "food": "bard"}) {
+		t.Errorf("error matching event tags")
+	}
+
+	ef = newEventFilter(configuration.EventsFilter{
+		TagDenyListSets: []map[string][]string{
 			{
 				"foo":  {"bar"},
 				"food": {"bard"},

--- a/plugins/sources/prometheus/prometheus_test.go
+++ b/plugins/sources/prometheus/prometheus_test.go
@@ -30,11 +30,11 @@ func TestNoFilters(t *testing.T) {
 	assert.Equal(t, 8, len(points), "wrong number of points")
 }
 
-func TestMetricWhitelist(t *testing.T) {
+func TestMetricAllowList(t *testing.T) {
 	cfg := filter.Config{
-		MetricWhitelist: []string{"*seconds.count*"},
+		MetricAllowList: []string{"*seconds.count*"},
 	}
-	f := filter.NewGlobFilter(cfg)
+	f := filter.FromConfig(cfg)
 
 	src := &prometheusMetricsSource{
 		filters: f,
@@ -47,11 +47,11 @@ func TestMetricWhitelist(t *testing.T) {
 	assert.Equal(t, 1, len(points), "wrong number of points")
 }
 
-func TestMetricBlacklist(t *testing.T) {
+func TestMetricDenyList(t *testing.T) {
 	cfg := filter.Config{
-		MetricBlacklist: []string{"*seconds.count*"},
+		MetricDenyList: []string{"*seconds.count*"},
 	}
-	f := filter.NewGlobFilter(cfg)
+	f := filter.FromConfig(cfg)
 
 	src := &prometheusMetricsSource{
 		filters: f,
@@ -64,11 +64,11 @@ func TestMetricBlacklist(t *testing.T) {
 	assert.Equal(t, 7, len(points), "wrong number of points")
 }
 
-func TestMetricTagWhitelist(t *testing.T) {
+func TestMetricTagAllowList(t *testing.T) {
 	cfg := filter.Config{
-		MetricTagWhitelist: map[string][]string{"label": {"good"}},
+		MetricTagAllowList: map[string][]string{"label": {"good"}},
 	}
-	f := filter.NewGlobFilter(cfg)
+	f := filter.FromConfig(cfg)
 
 	src := &prometheusMetricsSource{
 		filters: f,
@@ -81,11 +81,11 @@ func TestMetricTagWhitelist(t *testing.T) {
 	assert.Equal(t, 1, len(points), "wrong number of points")
 }
 
-func TestMetricTagBlacklist(t *testing.T) {
+func TestMetricTagDenyList(t *testing.T) {
 	cfg := filter.Config{
-		MetricTagBlacklist: map[string][]string{"label": {"ba*"}},
+		MetricTagDenyList: map[string][]string{"label": {"ba*"}},
 	}
-	f := filter.NewGlobFilter(cfg)
+	f := filter.FromConfig(cfg)
 
 	src := &prometheusMetricsSource{
 		filters: f,

--- a/plugins/sources/summary/converter_test.go
+++ b/plugins/sources/summary/converter_test.go
@@ -55,7 +55,7 @@ func TestFiltering(t *testing.T) {
 	fakeConverter := fakeWavefrontConverter(t, configuration.SummaySourceConfig{
 		Transforms: configuration.Transforms{
 			Filters: filter.Config{
-				MetricWhitelist: []string{"kubernetes*cpu*"},
+				MetricAllowList: []string{"kubernetes*cpu*"},
 			},
 		},
 	})
@@ -70,7 +70,7 @@ func TestFiltering(t *testing.T) {
 	fakeConverter = fakeWavefrontConverter(t, configuration.SummaySourceConfig{
 		Transforms: configuration.Transforms{
 			Filters: filter.Config{
-				MetricBlacklist: []string{"kubernetes*cpu*"},
+				MetricDenyList: []string{"kubernetes*cpu*"},
 			},
 		},
 	})

--- a/plugins/sources/systemd/filter.go
+++ b/plugins/sources/systemd/filter.go
@@ -10,26 +10,26 @@ import (
 )
 
 type unitFilter struct {
-	unitWhitelist glob.Glob
-	unitBlacklist glob.Glob
+	unitAllowList glob.Glob
+	unitDenyList  glob.Glob
 }
 
 func (uf *unitFilter) match(name string) bool {
-	if uf.unitWhitelist != nil && !uf.unitWhitelist.Match(name) {
+	if uf.unitAllowList != nil && !uf.unitAllowList.Match(name) {
 		return false
 	}
-	if uf.unitBlacklist != nil && uf.unitBlacklist.Match(name) {
+	if uf.unitDenyList != nil && uf.unitDenyList.Match(name) {
 		return false
 	}
 	return true
 }
 
-func fromConfig(whitelist, blacklist []string) *unitFilter {
-	if len(whitelist) == 0 && len(blacklist) == 0 {
+func fromConfig(allowList, denyList []string) *unitFilter {
+	if len(allowList) == 0 && len(denyList) == 0 {
 		return nil
 	}
 	return &unitFilter{
-		unitWhitelist: filter.Compile(whitelist),
-		unitBlacklist: filter.Compile(blacklist),
+		unitAllowList: filter.Compile(allowList),
+		unitDenyList:  filter.Compile(denyList),
 	}
 }

--- a/plugins/sources/systemd/filter_test.go
+++ b/plugins/sources/systemd/filter_test.go
@@ -12,35 +12,35 @@ import (
 func TestFromQuery(t *testing.T) {
 	cfg := configuration.SystemdSourceConfig{}
 
-	if fromConfig(cfg.UnitWhitelist, cfg.UnitBlacklist) != nil {
+	if fromConfig(cfg.UnitAllowList, cfg.UnitDenyList) != nil {
 		t.Errorf("error creating filter")
 	}
 
-	// test whitelisting
-	cfg.UnitWhitelist = []string{"docker*", "kubelet*"}
-	f := fromConfig(cfg.UnitWhitelist, cfg.UnitBlacklist)
+	// test allow lists
+	cfg.UnitAllowList = []string{"docker*", "kubelet*"}
+	f := fromConfig(cfg.UnitAllowList, cfg.UnitDenyList)
 	if f == nil {
 		t.Errorf("error creating filter")
 	}
-	if f.unitWhitelist == nil {
+	if f.unitAllowList == nil {
 		t.Errorf("error creating filter")
 	}
 	if !f.match("docker.service") {
-		t.Errorf("error matching whitelisted docker.service")
+		t.Errorf("error matching allowed docker.service")
 	}
 	if !f.match("kubelet.service") {
-		t.Errorf("error matching whitelisted kubelet.service")
+		t.Errorf("error matching allowed kubelet.service")
 	}
 	if f.match("random.service") {
 		t.Errorf("error matching random.service")
 	}
 
-	// test blacklisting
-	cfg.UnitWhitelist = nil
-	cfg.UnitBlacklist = []string{"*mount*", "etc*"}
-	f = fromConfig(cfg.UnitWhitelist, cfg.UnitBlacklist)
+	// test deny lists
+	cfg.UnitAllowList = nil
+	cfg.UnitDenyList = []string{"*mount*", "etc*"}
+	f = fromConfig(cfg.UnitAllowList, cfg.UnitDenyList)
 	if f.match("home.mount") {
-		t.Errorf("error matching blacklisted home.mount")
+		t.Errorf("error matching denied home.mount")
 	}
 	if !f.match("kubelet.service") {
 		t.Errorf("error matching kubelet.service")

--- a/plugins/sources/systemd/systemd.go
+++ b/plugins/sources/systemd/systemd.go
@@ -426,7 +426,7 @@ func NewProvider(cfg configuration.SystemdSourceConfig) (MetricsSourceProvider, 
 	collectStartTimeMetrics := cfg.IncludeStartTimeMetrics
 	collectRestartMetrics := cfg.IncludeRestartMetrics
 
-	unitsFilter := fromConfig(cfg.UnitWhitelist, cfg.UnitBlacklist)
+	unitsFilter := fromConfig(cfg.UnitAllowList, cfg.UnitDenyList)
 	filters := filter.FromConfig(cfg.Filters)
 
 	pt := map[string]string{"type": "systemd"}


### PR DESCRIPTION
- renames filter vars to use allow/deny-list terminlogy
- previous terms are deprecated for now (retained for backwards compat). We will remove that at a later stage.