### PR TITLE
Memory improvements

### DIFF
--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -43,8 +43,8 @@ type Resource struct {
 	Meta   metav1.ObjectMeta
 	Status string
 
-	PodSpec     v1.PodSpec
-	ServiceSpec v1.ServiceSpec
+	// list of containers for a pod resource
+	Containers []v1.Container
 }
 
 // Discoverer discovers endpoints from resources based on rules or annotations

--- a/plugins/discovery/discoverer.go
+++ b/plugins/discovery/discoverer.go
@@ -46,7 +46,7 @@ func newDiscoverer(handler metrics.ProviderHandler, discoveryCfg discovery.Confi
 		lister:          lister,
 		delegates:       makeDelegates(discoveryCfg),
 		ruleCount:       gm.GetOrRegisterGauge("discovery.rules.count", gm.DefaultRegistry),
-		endpoints:       make(map[string][]*discovery.Endpoint),
+		endpoints:       make(map[string][]*discovery.Endpoint, 32),
 		endpointHandler: discovery.NewEndpointHandler(makeProviders(handler, discoveryCfg)),
 	}
 	d.ruleCount.Update(int64(len(d.delegates)))

--- a/plugins/discovery/filter.go
+++ b/plugins/discovery/filter.go
@@ -68,7 +68,7 @@ func (r *resourceFilter) matches(resource discovery.Resource) bool {
 		return false
 	}
 	if r.images != nil {
-		for _, container := range resource.PodSpec.Containers {
+		for _, container := range resource.Containers {
 			if r.images.Match(container.Image) {
 				return true
 			}

--- a/plugins/discovery/filter_test.go
+++ b/plugins/discovery/filter_test.go
@@ -194,10 +194,8 @@ func TestAll(t *testing.T) {
 
 func makeResource(containers []v1.Container, labels map[string]string, ns string) discovery.Resource {
 	return discovery.Resource{
-		Kind: discovery.PodType.String(),
-		PodSpec: v1.PodSpec{
-			Containers: containers,
-		},
+		Kind:       discovery.PodType.String(),
+		Containers: containers,
 		Meta: metav1.ObjectMeta{
 			Labels:    labels,
 			Namespace: ns,

--- a/plugins/discovery/pod.go
+++ b/plugins/discovery/pod.go
@@ -37,10 +37,10 @@ func newPodHandler(kubeClient kubernetes.Interface, discoverer discovery.Discove
 		DeleteFunc: func(obj interface{}) {
 			pod := obj.(*v1.Pod)
 			discoverer.Delete(discovery.Resource{
-				Kind:    discovery.PodType.String(),
-				IP:      pod.Status.PodIP,
-				Meta:    pod.ObjectMeta,
-				PodSpec: pod.Spec,
+				Kind:       discovery.PodType.String(),
+				IP:         pod.Status.PodIP,
+				Meta:       pod.ObjectMeta,
+				Containers: pod.Spec.Containers,
 			})
 		},
 	})
@@ -52,10 +52,10 @@ func newPodHandler(kubeClient kubernetes.Interface, discoverer discovery.Discove
 func podUpdated(pod *v1.Pod, discoverer discovery.Discoverer) {
 	if podReady(pod) {
 		discoverer.Discover(discovery.Resource{
-			Kind:    discovery.PodType.String(),
-			IP:      pod.Status.PodIP,
-			Meta:    pod.ObjectMeta,
-			PodSpec: pod.Spec,
+			Kind:       discovery.PodType.String(),
+			IP:         pod.Status.PodIP,
+			Meta:       pod.ObjectMeta,
+			Containers: pod.Spec.Containers,
 		})
 	}
 }


### PR DESCRIPTION
- Fixed a memory leak in the rate calculator (we were holding onto deleted pods/containers forever). We now prune the internal cache every 5 minutes.
- Tweaked the discovery mechanism to kick off discovery only if pods/services are ready (IPs assigned and running). This reduces allocations & cpu usage in high churn environments.
