### PR TITLE
Chunked prom parsing to lower memory usage

### DIFF
--- a/cmd/wavefront-collector/main.go
+++ b/cmd/wavefront-collector/main.go
@@ -110,7 +110,7 @@ func createAgentOrDie(cfg *configuration.Config) *agent.Agent {
 	setEnvVar("omitBucketSuffix", strconv.FormatBool(cfg.OmitBucketSuffix))
 
 	// used to toggle which prometheus parsing we use
-	setEnvVar("useClassicPrometheusParser", strconv.FormatBool(cfg.UseClassicPrometheusParser))
+	setEnvVar("useClassicPrometheusParser", strconv.FormatBool(*cfg.UseClassicPrometheusParser))
 
 	clusterName := cfg.ClusterName
 
@@ -204,6 +204,10 @@ func fillDefaults(cfg *configuration.Config) {
 	}
 	if cfg.DiscoveryConfig.DiscoveryInterval == 0 {
 		cfg.DiscoveryConfig.DiscoveryInterval = 5 * time.Minute
+	}
+	if cfg.UseClassicPrometheusParser == nil {
+		classicParser := true
+		cfg.UseClassicPrometheusParser = &classicParser
 	}
 }
 

--- a/cmd/wavefront-collector/main.go
+++ b/cmd/wavefront-collector/main.go
@@ -109,6 +109,9 @@ func createAgentOrDie(cfg *configuration.Config) *agent.Agent {
 	// backwards compat: used by prometheus sources to format histogram metric names
 	setEnvVar("omitBucketSuffix", strconv.FormatBool(cfg.OmitBucketSuffix))
 
+	// used to toggle which prometheus parsing we use
+	setEnvVar("useClassicPrometheusParser", strconv.FormatBool(cfg.UseClassicPrometheusParser))
+
 	clusterName := cfg.ClusterName
 
 	kubeClient := createKubeClientOrDie(*cfg.Sources.SummaryConfig)

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	OmitBucketSuffix bool `yaml:"omitBucketSuffix"`
 
 	// whether to use the older prometheus parsing mechanism.
-	UseClassicPrometheusParser bool `yaml:"useClassicPrometheusParser"`
+	UseClassicPrometheusParser *bool `yaml:"useClassicPrometheusParser"`
 
 	// Internal use only
 	Daemon bool `yaml:"-"`

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -47,6 +47,9 @@ type Config struct {
 	// whether to omit the .bucket suffix for prometheus histogram metrics. Defaults to false.
 	OmitBucketSuffix bool `yaml:"omitBucketSuffix"`
 
+	// whether to use the older prometheus parsing mechanism.
+	UseClassicPrometheusParser bool `yaml:"useClassicPrometheusParser"`
+
 	// Internal use only
 	Daemon bool `yaml:"-"`
 }

--- a/plugins/sources/prometheus/lookahead_reader.go
+++ b/plugins/sources/prometheus/lookahead_reader.go
@@ -33,12 +33,12 @@ func (laReader *LookaheadReader) Read() []byte {
 	}
 	// the scanner slice changes unexpectedly in some cases so a defensive copy
 	// protects us from that
-	retVal:=makeDefensiveCopy(laReader.scanner.Bytes())
+	retVal := makeDefensiveCopy(laReader.scanner.Bytes())
 	laReader.advanceLine()
 	return retVal
 }
 
-func makeDefensiveCopy(buf []byte) []byte{
+func makeDefensiveCopy(buf []byte) []byte {
 	retVal := make([]byte, len(buf))
 	copy(retVal, buf)
 	return retVal

--- a/plugins/sources/prometheus/lookahead_reader.go
+++ b/plugins/sources/prometheus/lookahead_reader.go
@@ -1,0 +1,54 @@
+package prometheus
+
+import (
+	"bufio"
+	"io"
+)
+
+type LookaheadReader struct {
+	scanner   *bufio.Scanner
+	done      bool
+	lineCount int
+}
+
+func NewLookaheadReader(reader io.Reader) *LookaheadReader {
+	scanner := bufio.NewScanner(reader)
+	scanner.Split(bufio.ScanLines)
+
+	laReader := &LookaheadReader{
+		scanner: scanner,
+	}
+
+	laReader.advanceLine()
+	return laReader
+}
+
+func (laReader *LookaheadReader) Done() bool {
+	return laReader.done
+}
+
+func (laReader *LookaheadReader) Read() []byte {
+	if laReader.done {
+		return []byte{}
+	}
+	// the scanner slice changes unexpectedly in some cases so a defensive copy
+	// protects us from that
+	retVal:=makeDefensiveCopy(laReader.scanner.Bytes())
+	laReader.advanceLine()
+	return retVal
+}
+
+func makeDefensiveCopy(buf []byte) []byte{
+	retVal := make([]byte, len(buf))
+	copy(retVal, buf)
+	return retVal
+}
+
+func (laReader *LookaheadReader) advanceLine() {
+	laReader.lineCount++
+	laReader.done = !laReader.scanner.Scan()
+}
+
+func (laReader *LookaheadReader) Peek() []byte {
+	return laReader.scanner.Bytes()
+}

--- a/plugins/sources/prometheus/lookahead_reader_test.go
+++ b/plugins/sources/prometheus/lookahead_reader_test.go
@@ -1,0 +1,54 @@
+package prometheus_test
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/plugins/sources/prometheus"
+	"testing"
+)
+
+func TestLAEmptyFile(t *testing.T) {
+	byteReader := bytes.NewReader([]byte{})
+	reader := prometheus.NewLookaheadReader(byteReader)
+	assertEmptyLAReader(t, reader)
+}
+
+func TestLAOneLineRead(t *testing.T) {
+	line := []byte(`ONE LINE`)
+	byteReader := bytes.NewReader(line)
+	reader := prometheus.NewLookaheadReader(byteReader)
+
+	assert.False(t, reader.Done())
+	assert.Equal(t, line, reader.Peek())
+	assert.Equal(t, line, reader.Read())
+
+	assertEmptyLAReader(t, reader)
+}
+
+func TestLAMultiLineRead(t *testing.T) {
+	lineOne := []byte("ONE LINE")
+	lineTwo := []byte("TWO LINE")
+
+	file := append(lineOne,'\n')
+	file = append(file, lineTwo...)
+	file = append(file, '\n')
+
+	byteReader := bytes.NewReader(file)
+	reader := prometheus.NewLookaheadReader(byteReader)
+
+	assert.False(t, reader.Done())
+	assert.Equal(t, lineOne, reader.Peek())
+	assert.Equal(t, lineOne, reader.Read())
+
+	assert.False(t, reader.Done())
+	assert.Equal(t, lineTwo, reader.Peek())
+	assert.Equal(t, lineTwo, reader.Read())
+
+	assertEmptyLAReader(t, reader)
+}
+
+func assertEmptyLAReader(t *testing.T, reader *prometheus.LookaheadReader) {
+	assert.True(t, reader.Done())
+	assert.Empty(t, reader.Peek())
+	assert.Empty(t, reader.Read())
+}

--- a/plugins/sources/prometheus/lookahead_reader_test.go
+++ b/plugins/sources/prometheus/lookahead_reader_test.go
@@ -29,7 +29,7 @@ func TestLAMultiLineRead(t *testing.T) {
 	lineOne := []byte("ONE LINE")
 	lineTwo := []byte("TWO LINE")
 
-	file := append(lineOne,'\n')
+	file := append(lineOne, '\n')
 	file = append(file, lineTwo...)
 	file = append(file, '\n')
 

--- a/plugins/sources/prometheus/metric_reader.go
+++ b/plugins/sources/prometheus/metric_reader.go
@@ -1,0 +1,58 @@
+package prometheus
+
+import (
+	"bytes"
+	"io"
+)
+
+type MetricReader struct {
+	lar *LookaheadReader
+}
+
+func NewMetricReader(reader io.Reader) *MetricReader {
+	return &MetricReader{
+		lar: NewLookaheadReader(reader),
+	}
+}
+
+// Done tells us if there is anything left to read
+func (mReader *MetricReader) Done() bool {
+	return mReader.lar.Done()
+}
+
+func (mReader *MetricReader) Read() []byte {
+	buffer := bytes.NewBuffer(nil)
+
+	mReader.readComments(buffer)
+	mReader.readMetrics(buffer)
+
+	return buffer.Bytes()
+}
+
+func (mReader *MetricReader) readComments(buffer *bytes.Buffer) {
+	for !mReader.lar.Done() {
+		if !mReader.commentNext() {
+			break
+		}
+		buffer.Write(mReader.lar.Read())
+		buffer.Write([]byte("\n"))
+	}
+}
+
+func (mReader *MetricReader) commentNext() bool {
+	trimmed := bytes.TrimSpace(mReader.lar.Peek())
+	if 0 == bytes.Compare([]byte{}, trimmed) {
+		return true
+	}
+	return bytes.HasPrefix(mReader.lar.Peek(), []byte("#"))
+}
+
+func (mReader *MetricReader) readMetrics(buffer *bytes.Buffer) {
+	for !mReader.lar.Done() {
+		if bytes.HasPrefix(mReader.lar.Peek(), []byte("#")) {
+			break
+		}
+		buffer.Write(mReader.lar.Read())
+		buffer.Write([]byte("\n"))
+	}
+}

--- a/plugins/sources/prometheus/metric_reader_test.go
+++ b/plugins/sources/prometheus/metric_reader_test.go
@@ -13,18 +13,6 @@ func TestMetricEmptyFile(t *testing.T) {
 	assertEmptyMetricReader(t, reader)
 }
 
-// one metric
-// two metric
-// two metric sets
-
-//# HELP ack_level_update ack_level_update counter
-//# TYPE ack_level_update counter
-//ack_level_update{operation="TimerActiveQueueProcessor",type="history"} 1.599204e+06
-//ack_level_update{operation="TransferActiveQueueProcessor",type="history"} 1.599186e+06
-//# HELP acquire_shards_count acquire_shards_count counter
-//# TYPE acquire_shards_count counter
-//acquire_shards_count{operation="ShardController",type="history"} 2904
-
 var metricOne string = `# HELP ack_level_update ack_level_update counter
 # TYPE ack_level_update counter
 ack_level_update{operation="TimerActiveQueueProcessor",type="history"} 1.599204e+06
@@ -97,27 +85,6 @@ func TestMetricLeadingWhitespace(t *testing.T) {
 
 	assertEmptyMetricReader(t, reader)
 }
-
-//TODO remove
-//func TestMetricBigGuns(t *testing.T) {
-//
-//	file, err := ioutil.ReadFile("/Users/joe/workspace/prometheus-example-app/raw_metrics/kube_state_metrics")
-//	assert.NoError(t, err)
-//
-//	byteReader := bytes.NewReader(file)
-//	reader := prometheus.NewMetricReader(byteReader)
-//
-//	out, err := os.Create("/Users/joe/workspace/prometheus-example-app/raw_metrics/eaten")
-//	defer out.Close()
-//	assert.NoError(t,err)
-//
-//	writer := bufio.NewWriter(out)
-//	for !reader.Done() {
-//		metric := reader.Read()
-//		writer.Write(metric)
-//	}
-//	writer.Flush()
-//}
 
 func assertEmptyMetricReader(t *testing.T, reader *prometheus.MetricReader) {
 	assert.True(t, reader.Done())

--- a/plugins/sources/prometheus/metric_reader_test.go
+++ b/plugins/sources/prometheus/metric_reader_test.go
@@ -1,0 +1,125 @@
+package prometheus_test
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/plugins/sources/prometheus"
+	"testing"
+)
+
+func TestMetricEmptyFile(t *testing.T) {
+	byteReader := bytes.NewReader([]byte{})
+	reader := prometheus.NewMetricReader(byteReader)
+	assertEmptyMetricReader(t, reader)
+}
+
+// one metric
+// two metric
+// two metric sets
+
+//# HELP ack_level_update ack_level_update counter
+//# TYPE ack_level_update counter
+//ack_level_update{operation="TimerActiveQueueProcessor",type="history"} 1.599204e+06
+//ack_level_update{operation="TransferActiveQueueProcessor",type="history"} 1.599186e+06
+//# HELP acquire_shards_count acquire_shards_count counter
+//# TYPE acquire_shards_count counter
+//acquire_shards_count{operation="ShardController",type="history"} 2904
+
+var metricOne string = `# HELP ack_level_update ack_level_update counter
+# TYPE ack_level_update counter
+ack_level_update{operation="TimerActiveQueueProcessor",type="history"} 1.599204e+06
+ack_level_update{operation="TransferActiveQueueProcessor",type="history"} 1.599186e+06
+`
+
+var metricTwo string = `# HELP acquire_shards_count acquire_shards_count counter
+# TYPE acquire_shards_count counter
+acquire_shards_count{operation="ShardController",type="history"} 2904
+`
+
+func TestMetric(t *testing.T) {
+	file := append([]byte(metricOne), []byte(metricTwo)...)
+
+	byteReader := bytes.NewReader(file)
+	reader := prometheus.NewMetricReader(byteReader)
+
+	assert.False(t, reader.Done())
+	assert.Equal(t, metricOne, string(reader.Read()))
+
+	assert.False(t, reader.Done())
+	assert.Equal(t, metricTwo, string(reader.Read()))
+
+	assertEmptyMetricReader(t, reader)
+}
+
+func TestMetricBlankLines(t *testing.T) {
+	var spaced string = `
+# HELP ack_level_update ack_level_update counter
+  
+# TYPE ack_level_update counter
+  
+ack_level_update{operation="TimerActiveQueueProcessor",type="history"} 1.599204e+06
+
+ack_level_update{operation="TransferActiveQueueProcessor",type="history"} 1.599186e+06
+
+`
+
+	file := append([]byte(spaced), []byte(metricTwo)...)
+
+	byteReader := bytes.NewReader(file)
+	reader := prometheus.NewMetricReader(byteReader)
+
+	assert.False(t, reader.Done())
+	assert.Equal(t, spaced, string(reader.Read()))
+
+	assert.False(t, reader.Done())
+	assert.Equal(t, metricTwo, string(reader.Read()))
+
+	assertEmptyMetricReader(t, reader)
+}
+
+func TestMetricLeadingWhitespace(t *testing.T) {
+	leading := `  # HELP ack_level_update ack_level_update counter
+	# TYPE ack_level_update counter
+  ack_level_update{operation="TimerActiveQueueProcessor",type="history"} 1.599204e+06
+	ack_level_update{operation="TransferActiveQueueProcessor",type="history"} 1.599186e+06
+`
+
+	file := append([]byte(leading), []byte(metricTwo)...)
+
+	byteReader := bytes.NewReader(file)
+	reader := prometheus.NewMetricReader(byteReader)
+
+	assert.False(t, reader.Done())
+	assert.Equal(t, leading, string(reader.Read()))
+
+	assert.False(t, reader.Done())
+	assert.Equal(t, metricTwo, string(reader.Read()))
+
+	assertEmptyMetricReader(t, reader)
+}
+
+//TODO remove
+//func TestMetricBigGuns(t *testing.T) {
+//
+//	file, err := ioutil.ReadFile("/Users/joe/workspace/prometheus-example-app/raw_metrics/kube_state_metrics")
+//	assert.NoError(t, err)
+//
+//	byteReader := bytes.NewReader(file)
+//	reader := prometheus.NewMetricReader(byteReader)
+//
+//	out, err := os.Create("/Users/joe/workspace/prometheus-example-app/raw_metrics/eaten")
+//	defer out.Close()
+//	assert.NoError(t,err)
+//
+//	writer := bufio.NewWriter(out)
+//	for !reader.Done() {
+//		metric := reader.Read()
+//		writer.Write(metric)
+//	}
+//	writer.Flush()
+//}
+
+func assertEmptyMetricReader(t *testing.T, reader *prometheus.MetricReader) {
+	assert.True(t, reader.Done())
+	assert.Empty(t, reader.Read())
+}

--- a/plugins/sources/prometheus/prometheus.go
+++ b/plugins/sources/prometheus/prometheus.go
@@ -184,13 +184,13 @@ func readResponse(body io.ReadCloser, cLen int64) ([]byte, error) {
 }
 
 func (src *prometheusMetricsSource) parseMetrics(buf []byte) ([]*metrics.MetricPoint, error) {
-	var parser expfmt.TextParser
 
 	metricReader := NewMetricReader(bytes.NewReader(buf))
 
 	var points = make([]*metrics.MetricPoint,0)
 	var err error
 	for !metricReader.Done() {
+		var parser expfmt.TextParser
 		reader := bytes.NewReader(metricReader.Read())
 		metricFamilies, err := parser.TextToMetricFamilies(reader)
 		if err != nil {


### PR DESCRIPTION
MONIT-20817

Breaks the incoming prometheus scrape into groups of metrics to process individually. Shows 40% improvement on memory demands.