### PR TITLE
Add flag to disable annotation discovery

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,9 @@ discovery:
   # with the annotation "wavefront.com/discovery-config: 'true'". Default is false.
   enable_runtime_plugins: true
 
+  # disables discovery based on annotations. Default is false.
+  disable_annotation_discovery: false
+
   plugins:
   # see auto-discovery for details
 

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -28,6 +28,9 @@ Additional annotations that apply:
 - `prometheus.io/insecureSkipVerify`: Whether to skip https cert validation. Defaults to true.
 - `prometheus.io/serverName`: The cert hostname to verify for the discovered targets.
 
+### Disabling annotation Discovery
+Auto discovery based on pod annotations is enabled by default, but can be disabled by setting the `disable_annotation_discovery` configuration option to `true`.
+
 See an [example](https://github.com/wavefrontHQ/wavefront-kubernetes-collector/blob/master/deploy/examples/prometheus-annotations-example.yaml) for how to annotate a pod with the above annotations.
 
 ## Rule based discovery

--- a/internal/discovery/configs.go
+++ b/internal/discovery/configs.go
@@ -23,6 +23,9 @@ type Config struct {
 	// with the annotation "wavefront.com/discovery-config: 'true'". Defaults to false.
 	EnableRuntimePlugins bool `yaml:"enable_runtime_plugins"`
 
+	// disables annotation based discovery. Defaults to false.
+	DisableAnnotationDiscovery bool `yaml:"disable_annotation_discovery"`
+
 	// list of discovery rules
 	PluginConfigs []PluginConfig `yaml:"plugins"`
 

--- a/internal/discovery/endpoint.go
+++ b/internal/discovery/endpoint.go
@@ -38,25 +38,6 @@ func NewEndpointHandler(providers map[string]ProviderInfo) EndpointHandler {
 	}
 }
 
-func (d *defaultEndpointHandler) Encode(resource Resource, rule PluginConfig) (string, interface{}, bool) {
-	kind := resource.Kind
-	ip := resource.IP
-	meta := resource.Meta
-
-	if log.IsLevelEnabled(log.DebugLevel) {
-		log.WithFields(log.Fields{
-			"kind":      kind,
-			"name":      meta.Name,
-			"namespace": meta.Namespace,
-		}).Debug("handling resource")
-	}
-
-	if delegate, ok := d.providers[pluginType(rule)]; ok {
-		return delegate.Encoder.Encode(ip, kind, meta, rule)
-	}
-	return "", nil, false
-}
-
 func (d *defaultEndpointHandler) Add(ep *Endpoint) {
 	if delegate, ok := d.providers[ep.PluginType]; ok {
 		provider, err := delegate.Factory.Build(ep.Config)

--- a/internal/discovery/types.go
+++ b/internal/discovery/types.go
@@ -76,7 +76,6 @@ type Endpoint struct {
 
 // EndpointHandler handles the configuration of a source to collect data from discovered endpoints
 type EndpointHandler interface {
-	Encode(resource Resource, rule PluginConfig) (string, interface{}, bool)
 	Add(ep *Endpoint)
 	Delete(ep *Endpoint)
 }

--- a/internal/discovery/utils/encoding.go
+++ b/internal/discovery/utils/encoding.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/util/dummies.go
+++ b/internal/util/dummies.go
@@ -175,6 +175,12 @@ func NewDummyDataProcessor(latency time.Duration) *DummyDataProcessor {
 	}
 }
 
+func NewDummyProviderHandler(count int) *DummyProviderHandler {
+	return &DummyProviderHandler{
+		count: count,
+	}
+}
+
 type DummyProviderHandler struct {
 	count int
 }

--- a/plugins/discovery/endpoint_creator.go
+++ b/plugins/discovery/endpoint_creator.go
@@ -26,7 +26,7 @@ func (e *endpointCreator) discoverEndpointsWithRules(resource discovery.Resource
 func (e *endpointCreator) discoverEndpointsWithAnnotations(resource discovery.Resource) []*discovery.Endpoint {
 	var eps []*discovery.Endpoint
 	// delegate to runtime handlers if no matching delegate
-	if ep := e.makeEndpoint(resource, discovery.PluginConfig{Type: "prometheus", Name: "example"}); ep != nil {
+	if ep := e.makeEndpoint(resource, discovery.PluginConfig{Type: "prometheus"}); ep != nil {
 		eps = append(eps, ep)
 	}
 

--- a/plugins/discovery/endpoint_creator.go
+++ b/plugins/discovery/endpoint_creator.go
@@ -1,0 +1,72 @@
+package discovery
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/discovery"
+)
+
+type endpointCreator struct {
+	delegates                  map[string]*delegate
+	providers                  map[string]discovery.ProviderInfo
+	disableAnnotationDiscovery bool
+}
+
+func (e *endpointCreator) discoverEndpointsWithRules(resource discovery.Resource) []*discovery.Endpoint {
+	var eps []*discovery.Endpoint
+	for _, delegate := range e.delegates {
+		if delegate.filter.matches(resource) {
+			if ep := e.makeEndpoint(resource, delegate.plugin); ep != nil {
+				eps = append(eps, ep)
+			}
+		}
+	}
+	return eps
+}
+
+func (e *endpointCreator) discoverEndpointsWithAnnotations(resource discovery.Resource) []*discovery.Endpoint {
+	var eps []*discovery.Endpoint
+	// delegate to runtime handlers if no matching delegate
+	if ep := e.makeEndpoint(resource, discovery.PluginConfig{Type: "prometheus", Name: "example"}); ep != nil {
+		eps = append(eps, ep)
+	}
+
+	return eps
+}
+
+func (e *endpointCreator) discoverEndpoints(resource discovery.Resource) []*discovery.Endpoint {
+	eps := e.discoverEndpointsWithRules(resource)
+	if len(eps) == 0 && !e.disableAnnotationDiscovery {
+		eps = e.discoverEndpointsWithAnnotations(resource)
+	}
+	return eps
+}
+
+func (e *endpointCreator) makeEndpoint(resource discovery.Resource, plugin discovery.PluginConfig) *discovery.Endpoint {
+	if name, cfg, ok := e.Encode(resource, plugin); ok {
+		return &discovery.Endpoint{
+			Name:       name,
+			Config:     cfg,
+			PluginType: pluginType(plugin),
+		}
+	}
+	return nil
+}
+
+func (e *endpointCreator) Encode(resource discovery.Resource, rule discovery.PluginConfig) (string, interface{}, bool) {
+	kind := resource.Kind
+	ip := resource.IP
+	meta := resource.Meta
+
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		logrus.WithFields(logrus.Fields{
+			"kind":      kind,
+			"name":      meta.Name,
+			"namespace": meta.Namespace,
+		}).Debug("handling resource")
+	}
+
+	if delegate, ok := e.providers[pluginType(rule)]; ok {
+		return delegate.Encoder.Encode(ip, kind, meta, rule)
+	}
+	return "", nil, false
+}

--- a/plugins/discovery/endpoint_creator_test.go
+++ b/plugins/discovery/endpoint_creator_test.go
@@ -1,0 +1,73 @@
+package discovery
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/discovery"
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/metrics"
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/util"
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/plugins/discovery/prometheus"
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/plugins/discovery/telegraf"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func makeDummyProviders(handler metrics.ProviderHandler) map[string]discovery.ProviderInfo {
+	providers := make(map[string]discovery.ProviderInfo, 2)
+	providers["prometheus"] = prometheus.NewProviderInfo(handler, "prom.")
+	providers["telegraf"] = telegraf.NewProviderInfo(handler)
+	return providers
+}
+
+func Test_endpointCreator_discoverEndpoints_annotations_dont_happen_when_disabled(t *testing.T) {
+	e := &endpointCreator{
+		delegates:                  nil,
+		providers:                  makeDummyProviders(util.NewDummyProviderHandler(1)),
+		disableAnnotationDiscovery: true,
+	}
+
+	resource := discovery.Resource{
+		Kind:       discovery.PodType.String(),
+		IP:         "0.0.0.0",
+		Meta:       metav1.ObjectMeta{},
+		Containers: make([]v1.Container, 0),
+	}
+
+	got := e.discoverEndpoints(resource)
+	assert.Equal(t, 0, len(got))
+}
+
+func Test_endpointCreator_discoverEndpoints_annotations_happen_when_not_disabled(t *testing.T) {
+	e := &endpointCreator{
+		delegates:                  nil,
+		providers:                  makeDummyProviders(util.NewDummyProviderHandler(1)),
+		disableAnnotationDiscovery: false,
+	}
+
+	resource := discovery.Resource{
+		Kind:       discovery.PodType.String(),
+		IP:         "0.0.0.0",
+		Meta:       metav1.ObjectMeta{},
+		Containers: make([]v1.Container, 0),
+	}
+
+	got := e.discoverEndpoints(resource)
+	assert.Equal(t, 1, len(got))
+}
+
+func Test_endpointCreator_discoverEndpoints_annotations_happen_by_default(t *testing.T) {
+	e := &endpointCreator{
+		delegates: nil,
+		providers: makeDummyProviders(util.NewDummyProviderHandler(1)),
+	}
+
+	resource := discovery.Resource{
+		Kind:       discovery.PodType.String(),
+		IP:         "0.0.0.0",
+		Meta:       metav1.ObjectMeta{},
+		Containers: make([]v1.Container, 0),
+	}
+
+	got := e.discoverEndpoints(resource)
+	assert.Equal(t, 1, len(got))
+}


### PR DESCRIPTION
- Move discovery of endpoints from resources to new endpointCreator
- Add unit tests for new endpointCreator
- Add documentation about new config value disable_annotation_discovery

[MONIT-21378](https://wavefront.atlassian.net/browse/MONIT-21378)