### PR TITLE
Reduce debug log clutter

### DIFF
--- a/plugins/sources/prometheus/prometheus.go
+++ b/plugins/sources/prometheus/prometheus.go
@@ -251,7 +251,6 @@ func (src *prometheusMetricsSource) buildPoints(metricFamilies map[string]*dto.M
 			}
 		}
 	}
-	log.Debugf("%s total points: %d", src.Name(), len(result))
 	return result, nil
 }
 


### PR DESCRIPTION
Remove the group by group debug message in the prometheus debug logging