### PR TITLE
Fix: fatal error concurrent map iteration and map write

### DIFF
--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -194,11 +194,11 @@ func (m *MetricPoint) SetLabelPairs(pairs []LabelPair) {
 }
 
 func (m *MetricPoint) GetTags() map[string]string {
-
 	tags := make(map[string]string, len(m.labelPairs))
 	for _, labelPair := range m.labelPairs {
 		tags[*labelPair.Name] = *labelPair.Value
 	}
+
 	m.RLock()
 	defer m.RUnlock()
 	for k, v := range m.Tags {

--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -21,6 +21,7 @@
 package metrics
 
 import (
+	"sync"
 	"time"
 )
 
@@ -183,6 +184,7 @@ type MetricPoint struct {
 	Timestamp int64
 	Source    string
 	Tags      map[string]string
+	sync.RWMutex
 
 	labelPairs []LabelPair
 }
@@ -192,15 +194,16 @@ func (m *MetricPoint) SetLabelPairs(pairs []LabelPair) {
 }
 
 func (m *MetricPoint) GetTags() map[string]string {
+
 	tags := make(map[string]string, len(m.labelPairs))
 	for _, labelPair := range m.labelPairs {
 		tags[*labelPair.Name] = *labelPair.Value
 	}
-
+	m.RLock()
+	defer m.RUnlock()
 	for k, v := range m.Tags {
 		tags[k] = v
 	}
-
 	return tags
 }
 

--- a/plugins/sinks/wavefront/wavefront.go
+++ b/plugins/sinks/wavefront/wavefront.go
@@ -205,7 +205,9 @@ func (sink *wavefrontSink) send(batch *metrics.DataBatch) {
 			continue
 		}
 		tags := point.GetTags()
+		point.Lock()
 		tags["cluster"] = sink.ClusterName
+		point.Unlock()
 		sink.sendPoint(point.Metric, point.Value, point.Timestamp, point.Source, tags)
 	}
 


### PR DESCRIPTION
Fixes #60

```
fatal error: concurrent map iteration and map write
goroutine 50 [running]:
runtime.throw(0x190f5b3, 0x26)
	/usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc0001bec78 sp=0xc0001bec48 pc=0x437712
runtime.mapiternext(0xc0001bed70)
	/usr/local/go/src/runtime/map.go:853 +0x554 fp=0xc0001becf8 sp=0xc0001bec78 pc=0x410e94
github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/metrics.(*MetricPoint).GetTags(0xc0000bbb60, 0x0)
	/go/src/github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/metrics/types.go:205 +0x1b0 fp=0xc0001bedf0 sp=0xc0001becf8 pc=0xb770d0
github.com/wavefronthq/wavefront-collector-for-kubernetes/plugins/sinks/wavefront.(*wavefrontSink).send(0xc00042ac00, 0xc000894400)
	/go/src/github.com/wavefronthq/wavefront-collector-for-kubernetes/plugins/sinks/wavefront/wavefront.go:207 +0x125 fp=0xc0001beeb0 sp=0xc0001bedf0 pc=0x146f685
github.com/wavefronthq/wavefront-collector-for-kubernetes/plugins/sinks/wavefront.(*wavefrontSink).ExportData(0xc00042ac00, 0xc000894400)
	/go/src/github.com/wavefronthq/wavefront-collector-for-kubernetes/plugins/sinks/wavefront/wavefront.go:228 +0x35 fp=0xc0001beed0 sp=0xc0001beeb0 pc=0x146f915
github.com/wavefronthq/wavefront-collector-for-kubernetes/plugins/sinks.NewSinkManager.func1(0x1affe80, 0xc00042ac00, 0xc000204cc0, 0xc000204d20, 0xc000204d80)
	/go/src/github.com/wavefronthq/wavefront-collector-for-kubernetes/plugins/sinks/manager.go:79 +0x296 fp=0xc0001befb8 sp=0xc0001beed0 pc=0x155e3d6
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1374 +0x1 fp=0xc0001befc0 sp=0xc0001befb8 pc=0x46f5c1
created by github.com/wavefronthq/wavefront-collector-for-kubernetes/plugins/sinks.NewSinkManager
	/go/src/github.com/wavefronthq/wavefront-collector-for-kubernetes/plugins/sinks/manager.go:75 +0x21c
goroutine 1 [select (no cases), 160 minutes]:
main.waitForStop()
	/go/src/github.com/wavefronthq/wavefront-collector-for-kubernetes/cmd/wavefront-collector/main.go:466 +0x25
main.main()
	/go/src/github.com/wavefronthq/wavefront-collector-for-kubernetes/cmd/wavefront-collector/main.go:85 +0x2d1
```
