### PR TITLE
use docker build cache effectively for the container build to improve full-loop performance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# files that aren't necessary to build a binary
+adr
+deploy
+docs
+hack
+*.md
+*.yml
+
+# files that change frequently and invalidate the cache unnecessarily
+_output
+callgrind.out* # output by remake --profile

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _output
 .DS_Store
 osstp_golang.yml
 hack/kustomize/base/kustomization.yaml
+callgrind.out*


### PR DESCRIPTION
* the change that fixed this was adding a .dockerignore file to exclude
files that were unnecessarily busting the docker cache
* does not affect the test-proxy-container build (need to convert to
mulit-stage build first)
* shaves off 20 to 60 seconds of build time when all things are cached

Signed-off-by: John Cornish <jcornish@vmware.com>