### PR TITLE
Add cadvisor to integration test

### DIFF
--- a/hack/kustomize/base/collector.template.yaml
+++ b/hack/kustomize/base/collector.template.yaml
@@ -38,12 +38,12 @@ sources:
   kubernetes_state_source:
     prefix: 'kubernetes.'
 
-#  kubernetes_cadvisor_source:
-#    prefix: 'kubernetes.cadvisor.'
-#    filters:
-#      metricAllowList:
-#        - "kubernetes.cadvisor.container.cpu.cfs.throttled.seconds.total.counter"
-#        - "kubernetes.cadvisor.container.cpu.cfs.throttled.periods.total.counter"
+  kubernetes_cadvisor_source:
+    prefix: 'kubernetes.cadvisor.'
+    filters:
+      metricAllowList:
+        - "kubernetes.cadvisor.container.cpu.cfs.throttled.seconds.total.counter"
+        - "kubernetes.cadvisor.container.cpu.cfs.throttled.periods.total.counter"
 
   telegraf_sources:
   # enable all telegraf plugins

--- a/hack/kustomize/files/metrics.jsonl
+++ b/hack/kustomize/files/metrics.jsonl
@@ -53,6 +53,10 @@
 {"Name":"kernel.entropy.avail","Tags":{"cluster":"","source":""}}
 {"Name":"kernel.interrupts","Tags":{"cluster":"","source":""}}
 {"Name":"kernel.processes.forked","Tags":{"cluster":"","source":""}}
+{"Name":"kubernetes.cadvisor.container.cpu.cfs.throttled.periods.total.counter","Tags":{"cluster":"","container":"","id":"","image":"","name":"","namespace":"","pod":"","source":""}}
+{"Name":"kubernetes.cadvisor.container.cpu.cfs.throttled.periods.total.counter","Tags":{"cluster":"","id":"","namespace":"","pod":"","source":""}}
+{"Name":"kubernetes.cadvisor.container.cpu.cfs.throttled.seconds.total.counter","Tags":{"cluster":"","container":"","id":"","image":"","name":"","namespace":"","pod":"","source":""}}
+{"Name":"kubernetes.cadvisor.container.cpu.cfs.throttled.seconds.total.counter","Tags":{"cluster":"","id":"","namespace":"","pod":"","source":""}}
 {"Name":"kubernetes.cluster.cpu.limit","Tags":{"cluster":"","source":"","type":"cluster"}}
 {"Name":"kubernetes.cluster.cpu.request","Tags":{"cluster":"","source":"","type":"cluster"}}
 {"Name":"kubernetes.cluster.memory.limit","Tags":{"cluster":"","source":"","type":"cluster"}}

--- a/hack/kustomize/test.sh
+++ b/hack/kustomize/test.sh
@@ -51,7 +51,7 @@ cat files/metrics.jsonl  overlays/test-$K8S_ENV/metrics/additional.jsonl  > file
 
 while true ; do # wait until we get a good connection
   RES_CODE=$(curl --silent --output "$RES" --write-out "%{http_code}" --data-binary "@$DIR/files/combined-metrics.jsonl" "http://localhost:8888/metrics/diff")
-  [[ $RES_CODE -eq 0 ]] || break
+  [[ $RES_CODE -lt 200 ]] || break
 done
 
 if [[ $RES_CODE -gt 399 ]] ; then


### PR DESCRIPTION
Minor change outside of adding cAdvisor stuff: my curl returns '000' as an HTTP status code when it cannot connect to the server. Previously, we were using `-eq 0` to test if the test proxy server was up or not. Unfortunately, this doesn't seem to work on my newly imaged machine. So I'm using `-lt 200` instead which appears to do the right thing.