### PR TITLE
Notify only on regression (good to bad), not on consecutive failures

### DIFF
--- a/ci.Jenkinsfile
+++ b/ci.Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
     }
 
     post {
-        failure {
+        regression {
             slackSend (channel: '#tobs-k8po-team', color: '#FF0000', message: "BUILD FAILED: '<${env.BUILD_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>")
         }
         fixed {


### PR DESCRIPTION
To reduce the consecutive failure messages on slack team channel, using the [`regression` condition](https://www.jenkins.io/doc/book/pipeline/syntax/#post-conditions) to only alert on first failure in a PR. 