### PR TITLE
Remove MetricType from MetricValue since it's unused

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -207,9 +207,8 @@ var MetricUptime = Metric{
 	},
 	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
 		return MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: MetricCumulative,
-			IntValue:   time.Since(spec.CreationTime).Nanoseconds() / time.Millisecond.Nanoseconds()}
+			ValueType: ValueInt64,
+			IntValue:  time.Since(spec.CreationTime).Nanoseconds() / time.Millisecond.Nanoseconds()}
 	},
 }
 
@@ -236,9 +235,8 @@ var MetricCpuLoad = Metric{
 	},
 	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
 		return MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: MetricGauge,
-			IntValue:   int64(stat.Cpu.LoadAverage)}
+			ValueType: ValueInt64,
+			IntValue:  int64(stat.Cpu.LoadAverage)}
 	},
 }
 
@@ -255,9 +253,8 @@ var MetricCpuUsage = Metric{
 	},
 	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
 		return MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: MetricCumulative,
-			IntValue:   int64(stat.Cpu.Usage.Total)}
+			ValueType: ValueInt64,
+			IntValue:  int64(stat.Cpu.Usage.Total)}
 	},
 }
 
@@ -293,9 +290,8 @@ var MetricMemoryUsage = Metric{
 	},
 	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
 		return MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: MetricGauge,
-			IntValue:   int64(stat.Memory.Usage)}
+			ValueType: ValueInt64,
+			IntValue:  int64(stat.Memory.Usage)}
 	},
 }
 
@@ -312,9 +308,8 @@ var MetricMemoryCache = Metric{
 	},
 	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
 		return MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: MetricGauge,
-			IntValue:   int64(stat.Memory.Cache)}
+			ValueType: ValueInt64,
+			IntValue:  int64(stat.Memory.Cache)}
 	},
 }
 
@@ -331,9 +326,8 @@ var MetricMemoryRSS = Metric{
 	},
 	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
 		return MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: MetricGauge,
-			IntValue:   int64(stat.Memory.RSS)}
+			ValueType: ValueInt64,
+			IntValue:  int64(stat.Memory.RSS)}
 	},
 }
 
@@ -350,9 +344,8 @@ var MetricMemoryWorkingSet = Metric{
 	},
 	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
 		return MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: MetricGauge,
-			IntValue:   int64(stat.Memory.WorkingSet)}
+			ValueType: ValueInt64,
+			IntValue:  int64(stat.Memory.WorkingSet)}
 	},
 }
 
@@ -369,9 +362,8 @@ var MetricMemoryPageFaults = Metric{
 	},
 	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
 		return MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: MetricCumulative,
-			IntValue:   int64(stat.Memory.ContainerData.Pgfault)}
+			ValueType: ValueInt64,
+			IntValue:  int64(stat.Memory.ContainerData.Pgfault)}
 	},
 }
 
@@ -388,9 +380,8 @@ var MetricMemoryMajorPageFaults = Metric{
 	},
 	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
 		return MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: MetricCumulative,
-			IntValue:   int64(stat.Memory.ContainerData.Pgmajfault)}
+			ValueType: ValueInt64,
+			IntValue:  int64(stat.Memory.ContainerData.Pgmajfault)}
 	},
 }
 
@@ -411,9 +402,8 @@ var MetricNetworkRx = Metric{
 			rxBytes += interfaceStat.RxBytes
 		}
 		return MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: MetricCumulative,
-			IntValue:   int64(rxBytes),
+			ValueType: ValueInt64,
+			IntValue:  int64(rxBytes),
 		}
 	},
 }
@@ -435,9 +425,8 @@ var MetricNetworkRxErrors = Metric{
 			rxErrors += interfaceStat.RxErrors
 		}
 		return MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: MetricCumulative,
-			IntValue:   int64(rxErrors),
+			ValueType: ValueInt64,
+			IntValue:  int64(rxErrors),
 		}
 	},
 }
@@ -459,9 +448,8 @@ var MetricNetworkTx = Metric{
 			txBytes += interfaceStat.TxBytes
 		}
 		return MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: MetricCumulative,
-			IntValue:   int64(txBytes),
+			ValueType: ValueInt64,
+			IntValue:  int64(txBytes),
 		}
 	},
 }
@@ -483,9 +471,8 @@ var MetricNetworkTxErrors = Metric{
 			txErrors += interfaceStat.TxErrors
 		}
 		return MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: MetricCumulative,
-			IntValue:   int64(txErrors),
+			ValueType: ValueInt64,
+			IntValue:  int64(txErrors),
 		}
 	},
 }
@@ -816,9 +803,8 @@ var MetricFilesystemUsage = Metric{
 					LabelResourceID.Key: fs.Device,
 				},
 				MetricValue: MetricValue{
-					ValueType:  ValueInt64,
-					MetricType: MetricGauge,
-					IntValue:   int64(fs.Usage),
+					ValueType: ValueInt64,
+					IntValue:  int64(fs.Usage),
 				},
 			})
 		}
@@ -847,9 +833,8 @@ var MetricFilesystemLimit = Metric{
 					LabelResourceID.Key: fs.Device,
 				},
 				MetricValue: MetricValue{
-					ValueType:  ValueInt64,
-					MetricType: MetricGauge,
-					IntValue:   int64(fs.Limit),
+					ValueType: ValueInt64,
+					IntValue:  int64(fs.Limit),
 				},
 			})
 		}
@@ -878,9 +863,8 @@ var MetricFilesystemAvailable = Metric{
 					LabelResourceID.Key: fs.Device,
 				},
 				MetricValue: MetricValue{
-					ValueType:  ValueInt64,
-					MetricType: MetricGauge,
-					IntValue:   int64(fs.Available),
+					ValueType: ValueInt64,
+					IntValue:  int64(fs.Available),
 				},
 			})
 		}
@@ -910,9 +894,8 @@ var MetricFilesystemInodes = Metric{
 						LabelResourceID.Key: fs.Device,
 					},
 					MetricValue: MetricValue{
-						ValueType:  ValueInt64,
-						MetricType: MetricGauge,
-						IntValue:   int64(fs.Inodes),
+						ValueType: ValueInt64,
+						IntValue:  int64(fs.Inodes),
 					},
 				})
 			}
@@ -943,9 +926,8 @@ var MetricFilesystemInodesFree = Metric{
 						LabelResourceID.Key: fs.Device,
 					},
 					MetricValue: MetricValue{
-						ValueType:  ValueInt64,
-						MetricType: MetricGauge,
-						IntValue:   int64(fs.InodesFree),
+						ValueType: ValueInt64,
+						IntValue:  int64(fs.InodesFree),
 					},
 				})
 			}
@@ -981,9 +963,8 @@ var MetricAcceleratorMemoryTotal = Metric{
 					LabelAcceleratorID.Key:    ac.ID,
 				},
 				MetricValue: MetricValue{
-					ValueType:  ValueInt64,
-					MetricType: MetricGauge,
-					IntValue:   int64(ac.MemoryTotal),
+					ValueType: ValueInt64,
+					IntValue:  int64(ac.MemoryTotal),
 				},
 			})
 		}
@@ -1018,9 +999,8 @@ var MetricAcceleratorMemoryUsed = Metric{
 					LabelAcceleratorID.Key:    ac.ID,
 				},
 				MetricValue: MetricValue{
-					ValueType:  ValueInt64,
-					MetricType: MetricGauge,
-					IntValue:   int64(ac.MemoryUsed),
+					ValueType: ValueInt64,
+					IntValue:  int64(ac.MemoryUsed),
 				},
 			})
 		}
@@ -1055,9 +1035,8 @@ var MetricAcceleratorDutyCycle = Metric{
 					LabelAcceleratorID.Key:    ac.ID,
 				},
 				MetricValue: MetricValue{
-					ValueType:  ValueInt64,
-					MetricType: MetricGauge,
-					IntValue:   int64(ac.DutyCycle),
+					ValueType: ValueInt64,
+					IntValue:  int64(ac.DutyCycle),
 				},
 			})
 		}
@@ -1096,9 +1075,8 @@ var MetricDiskIORead = Metric{
 					LabelResourceID.Key: resourceIDKey,
 				},
 				MetricValue: MetricValue{
-					ValueType:  ValueInt64,
-					MetricType: MetricGauge,
-					IntValue:   int64(value),
+					ValueType: ValueInt64,
+					IntValue:  int64(value),
 				},
 			})
 		}
@@ -1137,9 +1115,8 @@ var MetricDiskIOWrite = Metric{
 					LabelResourceID.Key: resourceIDKey,
 				},
 				MetricValue: MetricValue{
-					ValueType:  ValueInt64,
-					MetricType: MetricGauge,
-					IntValue:   int64(value),
+					ValueType: ValueInt64,
+					IntValue:  int64(value),
 				},
 			})
 		}

--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -93,7 +93,6 @@ func (unitsType *UnitsType) String() string {
 type MetricValue struct {
 	IntValue   int64
 	FloatValue float64
-	MetricType MetricType
 	ValueType  ValueType
 }
 

--- a/plugins/manager/manager_test.go
+++ b/plugins/manager/manager_test.go
@@ -91,9 +91,8 @@ func createMetricSet(name string, metricType metrics.MetricType, value int64) *m
 	set := &metrics.MetricSet{
 		MetricValues: map[string]metrics.MetricValue{
 			name: {
-				MetricType: metricType,
-				ValueType:  metrics.ValueInt64,
-				IntValue:   value,
+				ValueType: metrics.ValueInt64,
+				IntValue:  value,
 			},
 		},
 	}

--- a/plugins/processors/cluster_aggregator_test.go
+++ b/plugins/processors/cluster_aggregator_test.go
@@ -37,14 +37,12 @@ func TestClusterAggregate(t *testing.T) {
 				},
 				MetricValues: map[string]metrics.MetricValue{
 					"m1": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   10,
+						ValueType: metrics.ValueInt64,
+						IntValue:  10,
 					},
 					"m2": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   222,
+						ValueType: metrics.ValueInt64,
+						IntValue:  222,
 					},
 				},
 			},
@@ -56,14 +54,12 @@ func TestClusterAggregate(t *testing.T) {
 				},
 				MetricValues: map[string]metrics.MetricValue{
 					"m1": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   100,
+						ValueType: metrics.ValueInt64,
+						IntValue:  100,
 					},
 					"m3": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   30,
+						ValueType: metrics.ValueInt64,
+						IntValue:  30,
 					},
 				},
 			},

--- a/plugins/processors/namespace_aggregator_test.go
+++ b/plugins/processors/namespace_aggregator_test.go
@@ -37,14 +37,12 @@ func TestNamespaceAggregate(t *testing.T) {
 				},
 				MetricValues: map[string]metrics.MetricValue{
 					"m1": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   10,
+						ValueType: metrics.ValueInt64,
+						IntValue:  10,
 					},
 					"m2": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   222,
+						ValueType: metrics.ValueInt64,
+						IntValue:  222,
 					},
 				},
 			},
@@ -56,14 +54,12 @@ func TestNamespaceAggregate(t *testing.T) {
 				},
 				MetricValues: map[string]metrics.MetricValue{
 					"m1": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   100,
+						ValueType: metrics.ValueInt64,
+						IntValue:  100,
 					},
 					"m3": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   30,
+						ValueType: metrics.ValueInt64,
+						IntValue:  30,
 					},
 				},
 			},

--- a/plugins/processors/node_aggregator_test.go
+++ b/plugins/processors/node_aggregator_test.go
@@ -38,14 +38,12 @@ func TestNodeAggregate(t *testing.T) {
 				},
 				MetricValues: map[string]metrics.MetricValue{
 					"m1": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   10,
+						ValueType: metrics.ValueInt64,
+						IntValue:  10,
 					},
 					"m2": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   222,
+						ValueType: metrics.ValueInt64,
+						IntValue:  222,
 					},
 				},
 			},
@@ -58,14 +56,12 @@ func TestNodeAggregate(t *testing.T) {
 				},
 				MetricValues: map[string]metrics.MetricValue{
 					"m1": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   100,
+						ValueType: metrics.ValueInt64,
+						IntValue:  100,
 					},
 					"m3": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   30,
+						ValueType: metrics.ValueInt64,
+						IntValue:  30,
 					},
 				},
 			},

--- a/plugins/processors/node_autoscaling_enricher.go
+++ b/plugins/processors/node_autoscaling_enricher.go
@@ -96,7 +96,6 @@ func getInt(metricSet *metrics.MetricSet, metric *metrics.Metric) int64 {
 
 func setFloat(metricSet *metrics.MetricSet, metric *metrics.Metric, value float64) {
 	metricSet.MetricValues[metric.MetricDescriptor.Name] = metrics.MetricValue{
-		MetricType: metrics.MetricGauge,
 		ValueType:  metrics.ValueFloat,
 		FloatValue: value,
 	}

--- a/plugins/processors/pod_aggregator_test.go
+++ b/plugins/processors/pod_aggregator_test.go
@@ -38,14 +38,12 @@ func TestPodAggregator(t *testing.T) {
 				},
 				MetricValues: map[string]metrics.MetricValue{
 					"m1": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   10,
+						ValueType: metrics.ValueInt64,
+						IntValue:  10,
 					},
 					"m2": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   222,
+						ValueType: metrics.ValueInt64,
+						IntValue:  222,
 					},
 				},
 			},
@@ -58,14 +56,12 @@ func TestPodAggregator(t *testing.T) {
 				},
 				MetricValues: map[string]metrics.MetricValue{
 					"m1": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   100,
+						ValueType: metrics.ValueInt64,
+						IntValue:  100,
 					},
 					"m3": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   30,
+						ValueType: metrics.ValueInt64,
+						IntValue:  30,
 					},
 				},
 			},
@@ -78,9 +74,8 @@ func TestPodAggregator(t *testing.T) {
 				},
 				MetricValues: map[string]metrics.MetricValue{
 					"m1": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   100,
+						ValueType: metrics.ValueInt64,
+						IntValue:  100,
 					},
 				},
 			},
@@ -93,14 +88,12 @@ func TestPodAggregator(t *testing.T) {
 				},
 				MetricValues: map[string]metrics.MetricValue{
 					"m1": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   10,
+						ValueType: metrics.ValueInt64,
+						IntValue:  10,
 					},
 					"m2": {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   20,
+						ValueType: metrics.ValueInt64,
+						IntValue:  20,
 					},
 				},
 			},

--- a/plugins/processors/pod_based_enricher.go
+++ b/plugins/processors/pod_based_enricher.go
@@ -318,9 +318,8 @@ func addLabeledIntMetric(ms *metrics.MetricSet, metric *metrics.Metric, labels m
 		Name:   metric.Name,
 		Labels: labels,
 		MetricValue: metrics.MetricValue{
-			ValueType:  metrics.ValueInt64,
-			MetricType: metric.Type,
-			IntValue:   value,
+			ValueType: metrics.ValueInt64,
+			IntValue:  value,
 		},
 	}
 	ms.LabeledMetrics = append(ms.LabeledMetrics, val)
@@ -328,9 +327,8 @@ func addLabeledIntMetric(ms *metrics.MetricSet, metric *metrics.Metric, labels m
 
 func intValue(value int64) metrics.MetricValue {
 	return metrics.MetricValue{
-		IntValue:   value,
-		MetricType: metrics.MetricGauge,
-		ValueType:  metrics.ValueInt64,
+		IntValue:  value,
+		ValueType: metrics.ValueInt64,
 	}
 }
 

--- a/plugins/processors/pod_based_enricher_test.go
+++ b/plugins/processors/pod_based_enricher_test.go
@@ -143,8 +143,7 @@ func TestStatusRunning(t *testing.T) {
 			"status": "running",
 		},
 		MetricValue: metrics.MetricValue{
-			IntValue:   1,
-			MetricType: metrics.MetricGauge,
+			IntValue: 1,
 		},
 	}
 	assert.Equal(t, expectedStatus, containerMs.LabeledMetrics[0])
@@ -177,8 +176,7 @@ func TestStatusTerminated(t *testing.T) {
 			"exit_code": "137",
 		},
 		MetricValue: metrics.MetricValue{
-			IntValue:   3,
-			MetricType: metrics.MetricGauge,
+			IntValue: 3,
 		},
 	}
 	assert.Equal(t, expectedStatus, containerMs.LabeledMetrics[0])
@@ -215,8 +213,7 @@ func TestStatusMissedTermination(t *testing.T) {
 			"exit_code": "137",
 		},
 		MetricValue: metrics.MetricValue{
-			IntValue:   3,
-			MetricType: metrics.MetricGauge,
+			IntValue: 3,
 		},
 	}
 	assert.Equal(t, expectedStatus, processBatch(t, podBasedEnricher, tc.batch))
@@ -250,8 +247,7 @@ func TestStatusPassedTermination(t *testing.T) {
 			"status": "running",
 		},
 		MetricValue: metrics.MetricValue{
-			IntValue:   1,
-			MetricType: metrics.MetricGauge,
+			IntValue: 1,
 		},
 	}
 	batch2 := createContainerBatch()

--- a/plugins/processors/rate_calculator.go
+++ b/plugins/processors/rate_calculator.go
@@ -90,7 +90,6 @@ func (rc *RateCalculator) Process(batch *metrics.DataBatch) (*metrics.DataBatch,
 								Labels: itemNew.Labels,
 								MetricValue: metrics.MetricValue{
 									ValueType:  metrics.ValueFloat,
-									MetricType: metrics.MetricGauge,
 									FloatValue: newVal,
 								},
 							})
@@ -109,9 +108,8 @@ func (rc *RateCalculator) Process(batch *metrics.DataBatch) (*metrics.DataBatch,
 						(newMs.ScrapeTime.UnixNano() - oldMs.ScrapeTime.UnixNano())
 
 					newMs.MetricValues[targetMetric.MetricDescriptor.Name] = metrics.MetricValue{
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricGauge,
-						IntValue:   newVal,
+						ValueType: metrics.ValueInt64,
+						IntValue:  newVal,
 					}
 
 				} else if foundNew && foundOld && targetMetric.MetricDescriptor.ValueType == metrics.ValueFloat {
@@ -120,7 +118,6 @@ func (rc *RateCalculator) Process(batch *metrics.DataBatch) (*metrics.DataBatch,
 
 					newMs.MetricValues[targetMetric.MetricDescriptor.Name] = metrics.MetricValue{
 						ValueType:  metrics.ValueFloat,
-						MetricType: metrics.MetricGauge,
 						FloatValue: newVal,
 					}
 				} else if foundNew && !foundOld || !foundNew && foundOld {

--- a/plugins/processors/rate_calculator_test.go
+++ b/plugins/processors/rate_calculator_test.go
@@ -42,14 +42,12 @@ func TestRateCalculator(t *testing.T) {
 				},
 				MetricValues: map[string]metrics.MetricValue{
 					metrics.MetricCpuUsage.MetricDescriptor.Name: {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricCumulative,
-						IntValue:   947130377781,
+						ValueType: metrics.ValueInt64,
+						IntValue:  947130377781,
 					},
 					metrics.MetricNetworkTxErrors.MetricDescriptor.Name: {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricCumulative,
-						IntValue:   0,
+						ValueType: metrics.ValueInt64,
+						IntValue:  0,
 					},
 				},
 			},
@@ -69,14 +67,12 @@ func TestRateCalculator(t *testing.T) {
 				},
 				MetricValues: map[string]metrics.MetricValue{
 					metrics.MetricCpuUsage.MetricDescriptor.Name: {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricCumulative,
-						IntValue:   948071062732,
+						ValueType: metrics.ValueInt64,
+						IntValue:  948071062732,
 					},
 					metrics.MetricNetworkTxErrors.MetricDescriptor.Name: {
-						ValueType:  metrics.ValueInt64,
-						MetricType: metrics.MetricCumulative,
-						IntValue:   120,
+						ValueType: metrics.ValueInt64,
+						IntValue:  120,
 					},
 				},
 			},

--- a/plugins/sources/summary/converter_test.go
+++ b/plugins/sources/summary/converter_test.go
@@ -116,9 +116,8 @@ func generateMetricSet(name string, metricType metrics.MetricType, value int64) 
 		Labels: fakeLabel,
 		MetricValues: map[string]metrics.MetricValue{
 			name: {
-				MetricType: metricType,
-				ValueType:  metrics.ValueInt64,
-				IntValue:   value,
+				ValueType: metrics.ValueInt64,
+				IntValue:  value,
 			},
 		},
 	}

--- a/plugins/sources/summary/summary.go
+++ b/plugins/sources/summary/summary.go
@@ -385,24 +385,10 @@ func (src *summaryMetricsSource) decodeFsStats(metrics *MetricSet, fsKey string,
 
 func (src *summaryMetricsSource) decodeUserDefinedMetrics(metrics *MetricSet, udm []stats.UserDefinedMetric) {
 	for _, metric := range udm {
-		mv := MetricValue{}
-		switch metric.Type {
-		case stats.MetricGauge:
-			mv.MetricType = MetricGauge
-		case stats.MetricCumulative:
-			mv.MetricType = MetricCumulative
-		case stats.MetricDelta:
-			mv.MetricType = MetricDelta
-		default:
-			log.Debugf("Skipping %s: unknown custom metric type: %v", metric.Name, metric.Type)
-			continue
+		metrics.MetricValues[CustomMetricPrefix+metric.Name] = MetricValue{
+			ValueType:  ValueFloat,
+			FloatValue: metric.Value,
 		}
-
-		// TODO: Handle double-precision values.
-		mv.ValueType = ValueFloat
-		mv.FloatValue = metric.Value
-
-		metrics.MetricValues[CustomMetricPrefix+metric.Name] = mv
 	}
 }
 
@@ -427,9 +413,8 @@ func (src *summaryMetricsSource) addIntMetric(metrics *MetricSet, metric *Metric
 		return
 	}
 	val := MetricValue{
-		ValueType:  ValueInt64,
-		MetricType: metric.Type,
-		IntValue:   int64(*value),
+		ValueType: ValueInt64,
+		IntValue:  int64(*value),
 	}
 	metrics.MetricValues[metric.Name] = val
 }
@@ -445,9 +430,8 @@ func (src *summaryMetricsSource) addLabeledIntMetric(metrics *MetricSet, metric 
 		Name:   metric.Name,
 		Labels: labels,
 		MetricValue: MetricValue{
-			ValueType:  ValueInt64,
-			MetricType: metric.Type,
-			IntValue:   int64(*value),
+			ValueType: ValueInt64,
+			IntValue:  int64(*value),
 		},
 	}
 	metrics.LabeledMetrics = append(metrics.LabeledMetrics, val)


### PR DESCRIPTION
Code search in Goland reveals that this field is only ever written to and never read.