### PR TITLE
Add annotation_excludes field to discovery config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ proxy-test: token-check $(SEMVER_CLI_BIN)
 deploy-test: token-check k8s-env clean-deployment deploy-targets proxy-test
 
 #Testing code, configuration and deployment changes
-integration-test: token-check k8s-env clean-deployment deploy-targets containers delete-images push-images proxy-test
+integration-test: token-check k8s-env clean-deployment deploy-targets container delete-images push-images proxy-test
 
 # creating this as separate and distinct for now,
 # but would like to recombine as a flag on integration-test

--- a/deploy/kubernetes/4-collector-config.yaml
+++ b/deploy/kubernetes/4-collector-config.yaml
@@ -99,6 +99,9 @@ data:
     # discovery rules for auto-discovery of pods and services
     discovery:
       enable_runtime_plugins: true
+      # annotation_excludes:
+      # - labels:
+      #     please-exclude-from-discovery: ['true']
 
       plugins:
 

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -38,6 +38,34 @@ discovery:
   disable_annotation_discovery: true
 ```
 
+### Excluding annotation discovered resources
+
+The collector can exclude resources from being detected by annotation-based discovery. It can have multiple exclusion 
+selectors. The collector will exclude a resource if any of the exclusion selectors match.
+
+```yaml
+discovery:
+  # Selectors for identifying kubernetes resources that should be excluded from annotation based discovery.
+  # One of images, labels or namespaces is required.
+  annotation_excludes:
+  - resourceType: pod # pod | service. Defaults to pod.
+
+    # The container images to match against. Provided as a list of glob pattern strings. Ex: 'redis*'
+    images:
+    - 'redis:*'
+    - '*redis*'
+
+    # map of labels to select resources by. Label values are provided as a list of glob pattern strings.
+    labels:
+      k8s-app:
+      - 'redis'
+      - '*cache*'
+
+    # namespaces to filter resources by. Provided as a list of glob pattern strings.
+    namespaces:
+    - default
+```
+
 ## Rule based discovery
 Discovery rules encompass a few distinct aspects:
 - *Selectors*: The criteria for identifying matching kubernetes resources using container images, resource labels and/or namespaces.

--- a/hack/test/.gitignore
+++ b/hack/test/.gitignore
@@ -2,5 +2,6 @@ overlays/**/proxy.yaml
 base/**/proxy.yaml
 extra.jsonl
 missing.jsonl
+unwanted.jsonl
 base/collector.yaml
 files/combined-metrics.jsonl

--- a/hack/test/base/collector.template.yaml
+++ b/hack/test/base/collector.template.yaml
@@ -17,6 +17,9 @@ sinks:
 # discovery rules for auto-discovery of pods and services
 discovery:
   enable_runtime_plugins: true
+  annotation_excludes:
+  - labels:
+      please-exclude-from-discovery: ['true']
 
 sources:
   kubernetes_source:

--- a/hack/test/base/proxy.template.yaml
+++ b/hack/test/base/proxy.template.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: wavefront-proxy
         image: projects.registry.vmware.com/tanzu_observability/proxy:10.13
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         env:
           - name: WAVEFRONT_URL
             value: https://YOUR_CLUSTER.wavefront.com/api/

--- a/hack/test/base/test-proxy.yaml
+++ b/hack/test/base/test-proxy.yaml
@@ -28,7 +28,7 @@ spec:
                       - amd64
       containers:
       - name: wavefront-proxy
-        image: projects.registry.vmware.com/tanzu_observability_keights_saas/test-proxy:1.7.4-v1
+        image: projects.registry.vmware.com/tanzu_observability_keights_saas/test-proxy:1.7.6
         imagePullPolicy: Always
         command: [ "/test-proxy", "-proxy", ":2878" ]
         ports:

--- a/hack/test/deploy/deploy-targets.sh
+++ b/hack/test/deploy/deploy-targets.sh
@@ -12,6 +12,7 @@ echo "Deploying targets..."
 kubectl create namespace collector-targets &> /dev/null || true
 
 kubectl apply -f prom-example.yaml &>/dev/null || true
+kubectl apply -f exclude-prom-example.yaml &>/dev/null || true
 kubectl apply -f cpu-throttled-prom-example.yaml &>/dev/null || true
 
 kubectl delete -f jobs.yaml &>/dev/null || true

--- a/hack/test/deploy/exclude-prom-example.yaml
+++ b/hack/test/deploy/exclude-prom-example.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    k8s-app: exclude-prom-example
+    name: exclude-prom-example
+    please-exclude-from-discovery: "true"
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/scheme: 'http'
+    prometheus.io/port: '8443'
+    prometheus.io/prefix: 'prom-example.'
+  name: exclude-prom-example
+  namespace: collector-targets
+spec:
+  containers:
+  - name: exclude-prom-example
+    image: projects.registry.vmware.com/tanzu_observability_keights_saas/prometheus-example-app:latest
+    imagePullPolicy: Always
+    command:
+    - /bin/prometheus-example-app
+    - --num=10
+    ports:
+    - containerPort: 8443
+      protocol: TCP

--- a/hack/test/files/metrics.jsonl
+++ b/hack/test/files/metrics.jsonl
@@ -4018,6 +4018,7 @@
 {"Name":"prom-example.workflow.cleanup.delete.counter","Value":"3","Tags":{"cluster":"","label.k8s-app":"prom-example","label.name":"prom-example","namespace":"","operation":"ProcessDeleteHistoryEvent","pod":"prom-example","source":"","type":"history"}}
 {"Name":"prom-example.workflow.context.cleared.counter","Value":"3","Tags":{"cluster":"","label.k8s-app":"prom-example","label.name":"prom-example","namespace":"","operation":"WorkflowContext","pod":"prom-example","source":"","type":"history"}}
 {"Name":"prom-example.workflow.cron.backoff.timer.counter","Value":"3","Tags":{"cluster":"","label.k8s-app":"prom-example","label.name":"prom-example","namespace":"","operation":"TimerActiveTaskWorkflowBackoffTimer","pod":"prom-example","source":"","type":"history"}}
+~{"Name":"prom-example.ack.level.update.counter","Value":"1599186","Tags":{"cluster":"","label.name":"exclude-prom-example","namespace":"collector-targets","operation":"TransferActiveQueueProcessor","pod":"exclude-prom-example","source":"","type":"history"}}
 {"Name":"swap.free","Tags":{"cluster":"","source":""}}
 {"Name":"swap.in","Tags":{"cluster":"","source":""}}
 {"Name":"swap.out","Tags":{"cluster":"","source":""}}

--- a/hack/test/test-integration.sh
+++ b/hack/test/test-integration.sh
@@ -54,18 +54,25 @@ if [[ $RES_CODE -gt 399 ]] ; then
   exit 1
 fi
 
-DIFF_COUNT=$(jq "(.Missing | length)" "$RES")
+DIFF_COUNT=$(jq "(.Missing | length) + (.Unwanted | length)" "$RES")
 EXIT_CODE=0
 
 jq -c '.Missing[]' "$RES" | sort > missing.jsonl
 jq -c '.Extra[]' "$RES" | sort > extra.jsonl
+jq -c '.Unwanted[]' "$RES" | sort > unwanted.jsonl
 
+echo "$RES"
 if [[ $DIFF_COUNT -gt 0 ]] ; then
-  red "MISSING: $(jq "(.Missing | length)" "$RES")"
-  cat missing.jsonl
+  red "Missing: $(jq "(.Missing | length)" "$RES")"
+  if [[ $(jq "(.Missing | length)" "$RES") -le 10 ]]; then
+    cat missing.jsonl
+  fi
+  red "Unwanted: $(jq "(.Unwanted | length)" "$RES")"
+  if [[ $(jq "(.Unwanted | length)" "$RES") -le 10 ]]; then
+    cat unwanted.jsonl
+  fi
   red "Extra: $(jq "(.Extra | length)" "$RES")"
-  red "FAILED: METRICS OUTPUT DID NOT MATCH EXACTLY"
-  echo "$RES"
+  red "FAILED: METRICS OUTPUT DID NOT MATCH"
   if which pbcopy > /dev/null; then
     echo "$RES" | pbcopy
   fi

--- a/internal/configuration/parser_test.go
+++ b/internal/configuration/parser_test.go
@@ -75,6 +75,10 @@ sources:
     - plugins: [mem]
 
 discovery:
+  annotation_excludes:
+  - images:
+    - 'not-redis:*'
+    - '*not-redis*'
   plugins:
   - type: telegraf/redis
     name: "redis"
@@ -109,4 +113,6 @@ func TestFromYAML(t *testing.T) {
 	assert.Equal(t, "kubernetes.", cfg.Sources.SummaryConfig.Prefix)
 	assert.Equal(t, "kube.apiserver.", cfg.Sources.PrometheusConfigs[0].Prefix)
 	assert.Equal(t, "kubernetes.cadvisor.", cfg.Sources.CadvisorConfig.Prefix)
+
+	assert.Equal(t, cfg.DiscoveryConfig.AnnotationExcludes[0].Images, []string{"not-redis:*", "*not-redis*"})
 }

--- a/internal/discovery/configs.go
+++ b/internal/discovery/configs.go
@@ -19,6 +19,9 @@ type Config struct {
 	// if specified, this substitutes the default prefix such as "prometheus.io" etc that is used during discovery
 	AnnotationPrefix string `yaml:"annotation_prefix"`
 
+	// AnnotationExcludes represents Selector rules for excluding kubernetes resources from annotation based discovery
+	AnnotationExcludes []Selectors `yaml:"annotation_excludes"`
+
 	// enables support for sourcing plugin configurations dynamically from configmaps
 	// with the annotation "wavefront.com/discovery-config: 'true'". Defaults to false.
 	EnableRuntimePlugins bool `yaml:"enable_runtime_plugins"`

--- a/make/k8s-envs/kind.mk
+++ b/make/k8s-envs/kind.mk
@@ -14,11 +14,9 @@ push-to-kind:
 	echo $(PREFIX)/$(DOCKER_IMAGE):$(VERSION)
 
 	@kind load docker-image $(PREFIX)/$(DOCKER_IMAGE):$(VERSION) --name kind
-	@kind load docker-image $(PREFIX)/test-proxy:$(VERSION) --name kind
 
 delete-images-kind:
 	@docker exec -it kind-control-plane crictl rmi $(PREFIX)/$(DOCKER_IMAGE):$(VERSION) || true
-	@docker exec -it kind-control-plane crictl rmi $(PREFIX)/test-proxy:$(VERSION) || true
 
 target-kind:
 	kubectl config use kind-kind

--- a/plugins/discovery/config.go
+++ b/plugins/discovery/config.go
@@ -234,9 +234,10 @@ func load(data map[string]string) (discovery.Config, error) {
 
 func combine(cfg discovery.Config, cfgs map[string]discovery.Config) discovery.Config {
 	runCfg := &discovery.Config{
-		DiscoveryInterval: cfg.DiscoveryInterval,
-		AnnotationPrefix:  cfg.AnnotationPrefix,
-		PluginConfigs:     cfg.PluginConfigs,
+		DiscoveryInterval:  cfg.DiscoveryInterval,
+		AnnotationPrefix:   cfg.AnnotationPrefix,
+		AnnotationExcludes: cfg.AnnotationExcludes,
+		PluginConfigs:      cfg.PluginConfigs,
 	}
 
 	// build a sorted slice of map keys for consistent iteration order

--- a/plugins/discovery/filter_test.go
+++ b/plugins/discovery/filter_test.go
@@ -14,12 +14,8 @@ import (
 
 func TestImages(t *testing.T) {
 	// single image
-	rf, err := newResourceFilter(discovery.PluginConfig{
-		Type: "telegraf/redis",
-		Selectors: discovery.Selectors{
-			Images: []string{"redis:*"},
-		},
-		Port: "6379",
+	rf, err := newResourceFilter(discovery.Selectors{
+		Images: []string{"redis:*"},
 	})
 	if err != nil {
 		t.Error(err)
@@ -40,12 +36,8 @@ func TestImages(t *testing.T) {
 	}
 
 	// multiple container images
-	rf, err = newResourceFilter(discovery.PluginConfig{
-		Type: "telegraf/redis",
-		Selectors: discovery.Selectors{
-			Images: []string{"redis:*", "*redisslave:v2"},
-		},
-		Port: "6379",
+	rf, err = newResourceFilter(discovery.Selectors{
+		Images: []string{"redis:*", "*redisslave:v2"},
 	})
 	if err != nil {
 		t.Error(err)
@@ -66,11 +58,8 @@ func TestImages(t *testing.T) {
 	}
 
 	// image without port
-	rf, err = newResourceFilter(discovery.PluginConfig{
-		Type: "telegraf/rabbitmq",
-		Selectors: discovery.Selectors{
-			Images: []string{"rabbitmq:*"},
-		},
+	rf, err = newResourceFilter(discovery.Selectors{
+		Images: []string{"rabbitmq:*"},
 	})
 	if err != nil {
 		t.Error(err)
@@ -83,14 +72,10 @@ func TestImages(t *testing.T) {
 }
 
 func TestLabels(t *testing.T) {
-	rf, err := newResourceFilter(discovery.PluginConfig{
-		Type: "telegraf/redis",
-		Selectors: discovery.Selectors{
-			Labels: map[string][]string{
-				"k8s-app": {"app1-redis*", "*app2-redis"},
-			},
+	rf, err := newResourceFilter(discovery.Selectors{
+		Labels: map[string][]string{
+			"k8s-app": {"app1-redis*", "*app2-redis"},
 		},
-		Port: "6379",
 	})
 	if err != nil {
 		t.Error(err)
@@ -111,15 +96,11 @@ func TestLabels(t *testing.T) {
 	}
 
 	// multiple labels
-	rf, err = newResourceFilter(discovery.PluginConfig{
-		Type: "telegraf/redis",
-		Selectors: discovery.Selectors{
-			Labels: map[string][]string{
-				"k8s-app": {"app1-redis*", "*app2-redis"},
-				"env":     {"dev-1", "dev-2"},
-			},
+	rf, err = newResourceFilter(discovery.Selectors{
+		Labels: map[string][]string{
+			"k8s-app": {"app1-redis*", "*app2-redis"},
+			"env":     {"dev-1", "dev-2"},
 		},
-		Port: "6379",
 	})
 	if err != nil {
 		t.Error(err)
@@ -135,12 +116,8 @@ func TestLabels(t *testing.T) {
 }
 
 func TestNamespaces(t *testing.T) {
-	rf, err := newResourceFilter(discovery.PluginConfig{
-		Type: "telegraf/redis",
-		Selectors: discovery.Selectors{
-			Namespaces: []string{"default*", "collector"},
-		},
-		Port: "6379",
+	rf, err := newResourceFilter(discovery.Selectors{
+		Namespaces: []string{"default*", "collector"},
 	})
 	if err != nil {
 		t.Error(err)
@@ -163,16 +140,12 @@ func TestNamespaces(t *testing.T) {
 }
 
 func TestAll(t *testing.T) {
-	rf, err := newResourceFilter(discovery.PluginConfig{
-		Type: "telegraf/redis",
-		Selectors: discovery.Selectors{
-			Images:     []string{"redis:*", "*redisslave:v2"},
-			Namespaces: []string{"default*", "collector"},
-			Labels: map[string][]string{
-				"k8s-app": {"app1-redis*", "*app2-redis"},
-			},
+	rf, err := newResourceFilter(discovery.Selectors{
+		Images:     []string{"redis:*", "*redisslave:v2"},
+		Namespaces: []string{"default*", "collector"},
+		Labels: map[string][]string{
+			"k8s-app": {"app1-redis*", "*app2-redis"},
 		},
-		Port: "6379",
 	})
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Other changes
 * Stop building the test-proxy on every integration test since we're not actually using the locally built version
 * test-proxy
    + allow metric patterns posted to `/metrics/diff` to contain `~` in front of the whole metric to signal that it should be excluded
    + Add an Unwanted field to report metrics that should have been excluded but were not
 * integration-test
     + fail if there are any Unwanted metrics
     + add excluded metric that tests new `annotation_excludes` config