### PR TITLE
Check login before building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ endif
 BUILDER_SUFFIX=$(shell echo $(PREFIX) | cut -d '/' -f1)
 
 publish:
+	docker login projects.registry.vmware.com/tanzu_observability_keights_saas
+
 	docker buildx create --use --node wavefront_collector_builder_$(BUILDER_SUFFIX)
 ifeq ($(RELEASE_TYPE), release)
 	docker buildx build --platform linux/amd64,linux/arm64 --push \


### PR DESCRIPTION
Check our login status with the repo before trying to build and push to it. Also provides a place to preserve the knowledge that this login is required.