### PR TITLE
Exclude completed pods from node, namespace, and cluster aggregates

### DIFF
--- a/cmd/wavefront-collector/main.go
+++ b/cmd/wavefront-collector/main.go
@@ -345,15 +345,10 @@ func createDataProcessorsOrDie(kubeClient *kube_client.Clientset, cluster string
 
 	dataProcessors = append(dataProcessors,
 		processors.NewPodAggregator(),
-		&processors.NamespaceAggregator{
-			MetricsToAggregate: metricsToAggregate,
-		},
-		&processors.NodeAggregator{
-			MetricsToAggregate: metricsToAggregateForNode,
-		},
-		&processors.ClusterAggregator{
-			MetricsToAggregate: metricsToAggregate,
-		})
+		processors.NewNamespaceAggregator(metricsToAggregate),
+		processors.NewNodeAggregator(metricsToAggregateForNode),
+		processors.NewClusterAggregator(metricsToAggregate),
+	)
 
 	nodeAutoscalingEnricher, err := processors.NewNodeAutoscalingEnricher(kubeClient, labelCopier)
 	if err != nil {

--- a/hack/test/files/metrics.jsonl
+++ b/hack/test/files/metrics.jsonl
@@ -231,9 +231,9 @@
 {"Name":"kubernetes.ns.memory.usage","Tags":{"cluster":"","namespace_name":"wavefront-collector","source":"","type":"ns"}}
 {"Name":"kubernetes.ns.memory.usage","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"}}
 {"Name":"kubernetes.ns.pod.count","Tags":{"cluster":"","namespace_name":"wavefront-collector","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.pod.count","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"},"Value": "5"}
+{"Name":"kubernetes.ns.pod.count","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"}}
 {"Name":"kubernetes.ns.pod_container.count","Tags":{"cluster":"","namespace_name":"wavefront-collector","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.pod_container.count","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"},"Value": "9"}
+{"Name":"kubernetes.ns.pod_container.count","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"}}
 {"Name":"kubernetes.pod.cpu.limit","Tags":{"cluster":"","label.app":"wavefront-proxy","namespace_name":"wavefront-collector","nodename":"","pod_name":"","source":"","type":"pod"}}
 {"Name":"kubernetes.pod.cpu.limit","Tags":{"cluster":"","label.app.kubernetes.io/component":"primary","label.app.kubernetes.io/instance":"mysql-release","label.app.kubernetes.io/managed-by":"Helm","label.app.kubernetes.io/name":"mysql","label.helm.sh/chart":"","label.statefulset.kubernetes.io/pod-name":"mysql-release-0","namespace_name": "collector-targets","nodename":"","pod_name":"","source":"","type":"pod"}}
 {"Name":"kubernetes.pod.cpu.limit","Tags":{"cluster":"","label.app.kubernetes.io/instance":"memcached-release","label.app.kubernetes.io/managed-by":"Helm","label.app.kubernetes.io/name":"memcached","label.helm.sh/chart":"","namespace_name": "collector-targets","nodename":"","pod_name":"","source":"","type":"pod"}}

--- a/hack/test/files/metrics.jsonl
+++ b/hack/test/files/metrics.jsonl
@@ -221,26 +221,19 @@
 {"Name":"kubernetes.node.status.condition","Tags":{"cluster":"","condition":"","!label.kubernetes.io/arch":"","label.kubernetes.io/hostname":"","label.kubernetes.io/os":"linux","nodename":"","source":"","status":"","node_role":""}}
 {"Name":"kubernetes.node.uptime","Tags":{"cluster":"","!label.kubernetes.io/arch":"","label.kubernetes.io/hostname":"","label.kubernetes.io/os":"linux","nodename":"","source":"","type":"node","node_role":""}}
 {"Name":"kubernetes.ns.cpu.limit","Tags":{"cluster":"","namespace_name":"wavefront-collector","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.cpu.limit","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.cpu.limit","Tags":{"cluster":"","namespace_name":"","source":"","type":"ns"}}
+{"Name":"kubernetes.ns.cpu.limit","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"},"Value": "10"}
 {"Name":"kubernetes.ns.cpu.request","Tags":{"cluster":"","namespace_name":"wavefront-collector","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.cpu.request","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.cpu.request","Tags":{"cluster":"","namespace_name":"","source":"","type":"ns"}}
+{"Name":"kubernetes.ns.cpu.request","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"},"Value": "110"}
 {"Name":"kubernetes.ns.memory.limit","Tags":{"cluster":"","namespace_name":"wavefront-collector","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.memory.limit","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.memory.limit","Tags":{"cluster":"","namespace_name":"","source":"","type":"ns"}}
+{"Name":"kubernetes.ns.memory.limit","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"},"Value": "134217728"}
 {"Name":"kubernetes.ns.memory.request","Tags":{"cluster":"","namespace_name":"wavefront-collector","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.memory.request","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.memory.request","Tags":{"cluster":"","namespace_name":"","source":"","type":"ns"}}
+{"Name":"kubernetes.ns.memory.request","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"},"Value": "171966464"}
 {"Name":"kubernetes.ns.memory.usage","Tags":{"cluster":"","namespace_name":"wavefront-collector","source":"","type":"ns"}}
 {"Name":"kubernetes.ns.memory.usage","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.memory.usage","Tags":{"cluster":"","namespace_name":"","source":"","type":"ns"}}
 {"Name":"kubernetes.ns.pod.count","Tags":{"cluster":"","namespace_name":"wavefront-collector","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.pod.count","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.pod.count","Tags":{"cluster":"","namespace_name":"","source":"","type":"ns"}}
+{"Name":"kubernetes.ns.pod.count","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"},"Value": "5"}
 {"Name":"kubernetes.ns.pod_container.count","Tags":{"cluster":"","namespace_name":"wavefront-collector","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.pod_container.count","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"}}
-{"Name":"kubernetes.ns.pod_container.count","Tags":{"cluster":"","namespace_name":"","source":"","type":"ns"}}
+{"Name":"kubernetes.ns.pod_container.count","Tags":{"cluster":"","namespace_name": "collector-targets","source":"","type":"ns"},"Value": "9"}
 {"Name":"kubernetes.pod.cpu.limit","Tags":{"cluster":"","label.app":"wavefront-proxy","namespace_name":"wavefront-collector","nodename":"","pod_name":"","source":"","type":"pod"}}
 {"Name":"kubernetes.pod.cpu.limit","Tags":{"cluster":"","label.app.kubernetes.io/component":"primary","label.app.kubernetes.io/instance":"mysql-release","label.app.kubernetes.io/managed-by":"Helm","label.app.kubernetes.io/name":"mysql","label.helm.sh/chart":"","label.statefulset.kubernetes.io/pod-name":"mysql-release-0","namespace_name": "collector-targets","nodename":"","pod_name":"","source":"","type":"pod"}}
 {"Name":"kubernetes.pod.cpu.limit","Tags":{"cluster":"","label.app.kubernetes.io/instance":"memcached-release","label.app.kubernetes.io/managed-by":"Helm","label.app.kubernetes.io/name":"memcached","label.helm.sh/chart":"","namespace_name": "collector-targets","nodename":"","pod_name":"","source":"","type":"pod"}}

--- a/internal/metrics/resource_key.go
+++ b/internal/metrics/resource_key.go
@@ -58,16 +58,16 @@ func ClusterKey() ResourceKey {
 	return "cluster"
 }
 
-type SetKeys []ResourceKey
+type ResourceKeys []ResourceKey
 
-func (s SetKeys) Len() int {
+func (s ResourceKeys) Len() int {
 	return len(s)
 }
 
-func (s SetKeys) Less(i, j int) bool {
+func (s ResourceKeys) Less(i, j int) bool {
 	return string(s[i]) < string(s[j])
 }
 
-func (s SetKeys) Swap(i, j int) {
+func (s ResourceKeys) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }

--- a/internal/metrics/set.go
+++ b/internal/metrics/set.go
@@ -26,14 +26,16 @@ func (s *Set) FindLabels(name string) (map[string]string, bool) {
 	for _, labeledValue := range s.LabeledValues {
 		if labeledValue.Name == name {
 			labels := make(map[string]string, len(s.Labels)+len(labeledValue.Labels))
-			for k, v := range labeledValue.Labels {
-				labels[k] = v
-			}
-			for k, v := range s.Labels {
-				labels[k] = v
-			}
+			copyLabels(labels, labeledValue.Labels)
+			copyLabels(labels, s.Labels)
 			return labels, true
 		}
 	}
 	return map[string]string{}, false
+}
+
+func copyLabels(dst, src map[string]string) {
+	for k, v := range src {
+		dst[k] = v
+	}
 }

--- a/internal/metrics/set.go
+++ b/internal/metrics/set.go
@@ -1,0 +1,39 @@
+package metrics
+
+import "time"
+
+// Set is a collection of metrics tied to a specific resource
+type Set struct {
+	// CollectionStartTime is a time since when the metrics are collected for this entity.
+	// It is affected by events like entity (e.g. pod) creation, entity restart (e.g. for container),
+	// Kubelet restart.
+	CollectionStartTime time.Time
+	// EntityCreateTime is a time of entity creation and persists through entity restarts and
+	// Kubelet restarts.
+	EntityCreateTime time.Time
+	ScrapeTime       time.Time
+	Values           map[string]Value
+	Labels           map[string]string
+	LabeledValues    []LabeledValue
+}
+
+// FindLabels returns the labels for a given metric name
+func (s *Set) FindLabels(name string) (map[string]string, bool) {
+	_, found := s.Values[name]
+	if found {
+		return s.Labels, true
+	}
+	for _, labeledValue := range s.LabeledValues {
+		if labeledValue.Name == name {
+            labels := make(map[string]string, len(s.Labels) + len(labeledValue.Labels))
+            for k, v := range labeledValue.Labels {
+                labels[k] = v
+            }
+            for k, v := range s.Labels {
+                labels[k] = v
+            }
+			return labels, true
+		}
+	}
+	return map[string]string{}, false
+}

--- a/internal/metrics/set.go
+++ b/internal/metrics/set.go
@@ -25,13 +25,13 @@ func (s *Set) FindLabels(name string) (map[string]string, bool) {
 	}
 	for _, labeledValue := range s.LabeledValues {
 		if labeledValue.Name == name {
-            labels := make(map[string]string, len(s.Labels) + len(labeledValue.Labels))
-            for k, v := range labeledValue.Labels {
-                labels[k] = v
-            }
-            for k, v := range s.Labels {
-                labels[k] = v
-            }
+			labels := make(map[string]string, len(s.Labels)+len(labeledValue.Labels))
+			for k, v := range labeledValue.Labels {
+				labels[k] = v
+			}
+			for k, v := range s.Labels {
+				labels[k] = v
+			}
 			return labels, true
 		}
 	}

--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -120,21 +120,6 @@ func (l *LabeledValue) GetValue() interface{} {
 	}
 }
 
-// Set is a collection of metrics tied to a specific resource
-type Set struct {
-	// CollectionStartTime is a time since when the metrics are collected for this entity.
-	// It is affected by events like entity (e.g. pod) creation, entity restart (e.g. for container),
-	// Kubelet restart.
-	CollectionStartTime time.Time
-	// EntityCreateTime is a time of entity creation and persists through entity restarts and
-	// Kubelet restarts.
-	EntityCreateTime time.Time
-	ScrapeTime       time.Time
-	Values           map[string]Value
-	Labels           map[string]string
-	LabeledValues    []LabeledValue
-}
-
 // Batch contains sets of metrics tied to specific k8s resources and other more general wavefront points
 type Batch struct {
 	Timestamp time.Time

--- a/plugins/processors/cluster_aggregator.go
+++ b/plugins/processors/cluster_aggregator.go
@@ -26,24 +26,24 @@ func NewClusterAggregator(metricsToAggregate []string) metrics.Processor {
 		{
 			ResourceSumMetrics:  metricsToAggregate,
 			ResourceCountMetric: metrics.MetricPodCount.Name,
-			ShouldAggregate:     isType(metrics.MetricSetTypeNamespace),
-			ExtractGroup:        groupByCluster,
+			isPartOfGroup:       isType(metrics.MetricSetTypeNamespace),
+			Group:               clusterGroup,
 		},
 		{
 			ResourceSumMetrics:  []string{},
 			ResourceCountMetric: metrics.MetricPodContainerCount.Name,
-			ShouldAggregate:     isType(metrics.MetricSetTypeNamespace),
-			ExtractGroup:        groupByCluster,
+			isPartOfGroup:       isType(metrics.MetricSetTypeNamespace),
+			Group:               clusterGroup,
 		},
 	})
 }
 
-func groupByCluster(batch *metrics.Batch, _ metrics.ResourceKey, _ *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+func clusterGroup(batch *metrics.Batch, _ metrics.ResourceKey, _ *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
 	clusterSet := batch.Sets[metrics.ClusterKey()]
 	if clusterSet == nil {
 		clusterSet = clusterMetricSet()
 	}
-	return metrics.ClusterKey(), clusterSet, nil
+	return metrics.ClusterKey(), clusterSet
 }
 
 func clusterMetricSet() *metrics.Set {

--- a/plugins/processors/cluster_aggregator.go
+++ b/plugins/processors/cluster_aggregator.go
@@ -18,7 +18,7 @@
 package processors
 
 import (
-    "github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/metrics"
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/metrics"
 )
 
 type ClusterAggregator struct {
@@ -30,15 +30,15 @@ func (aggregator *ClusterAggregator) Name() string {
 }
 
 func (aggregator *ClusterAggregator) Process(batch *metrics.Batch) (*metrics.Batch, error) {
-    err := aggregateByGroup(batch, groupByCluster, isType(metrics.MetricSetTypeNamespace), &metrics.MetricPodCount, aggregator.MetricsToAggregate)
-    if err != nil {
-        return nil, err
-    }
-    err = aggregateByGroup(batch, groupByCluster, isType(metrics.MetricSetTypeNamespace), &metrics.MetricPodContainerCount, []string{})
-    if err != nil {
-        return nil, err
-    }
-    return batch, nil
+	err := aggregateByGroup(batch, groupByCluster, isType(metrics.MetricSetTypeNamespace), &metrics.MetricPodCount, aggregator.MetricsToAggregate)
+	if err != nil {
+		return nil, err
+	}
+	err = aggregateByGroup(batch, groupByCluster, isType(metrics.MetricSetTypeNamespace), &metrics.MetricPodContainerCount, []string{})
+	if err != nil {
+		return nil, err
+	}
+	return batch, nil
 	//clusterKey := metrics.ClusterKey()
 	//cluster := clusterMetricSet()
 	//for _, metricSet := range batch.Sets {
@@ -51,17 +51,17 @@ func (aggregator *ClusterAggregator) Process(batch *metrics.Batch) (*metrics.Bat
 	//		aggregateCount(metricSet, cluster, metrics.MetricPodContainerCount.Name)
 	//	}
 	//}
-    //
+	//
 	//batch.Sets[clusterKey] = cluster
 	//return batch, nil
 }
 
 func groupByCluster(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
-    clusterSet := batch.Sets[metrics.ClusterKey()]
-    if clusterSet == nil {
-        clusterSet = clusterMetricSet()
-    }
-    return metrics.ClusterKey(), clusterSet, nil
+	clusterSet := batch.Sets[metrics.ClusterKey()]
+	if clusterSet == nil {
+		clusterSet = clusterMetricSet()
+	}
+	return metrics.ClusterKey(), clusterSet, nil
 }
 
 func clusterMetricSet() *metrics.Set {

--- a/plugins/processors/cluster_aggregator.go
+++ b/plugins/processors/cluster_aggregator.go
@@ -26,13 +26,13 @@ func NewClusterAggregator(metricsToAggregate []string) metrics.Processor {
 		{
 			ResourceSumMetrics:  metricsToAggregate,
 			ResourceCountMetric: metrics.MetricPodCount.Name,
-			isPartOfGroup:       isType(metrics.MetricSetTypeNamespace),
+			IsPartOfGroup:       isType(metrics.MetricSetTypeNamespace),
 			Group:               clusterGroup,
 		},
 		{
 			ResourceSumMetrics:  []string{},
 			ResourceCountMetric: metrics.MetricPodContainerCount.Name,
-			isPartOfGroup:       isType(metrics.MetricSetTypeNamespace),
+			IsPartOfGroup:       isType(metrics.MetricSetTypeNamespace),
 			Group:               clusterGroup,
 		},
 	})

--- a/plugins/processors/cluster_aggregator_test.go
+++ b/plugins/processors/cluster_aggregator_test.go
@@ -81,9 +81,7 @@ func TestClusterAggregate(t *testing.T) {
 			},
 		},
 	}
-	processor := ClusterAggregator{
-		MetricsToAggregate: []string{"m1", "m3"},
-	}
+	processor := NewClusterAggregator([]string{"m1", "m3"})
 	result, err := processor.Process(&batch)
 	assert.NoError(t, err)
 	cluster, found := result.Sets[metrics.ClusterKey()]

--- a/plugins/processors/cluster_aggregator_test.go
+++ b/plugins/processors/cluster_aggregator_test.go
@@ -30,7 +30,7 @@ func TestClusterAggregate(t *testing.T) {
 	batch := metrics.Batch{
 		Timestamp: time.Now(),
 		Sets: map[metrics.ResourceKey]*metrics.Set{
-			metrics.PodKey("ns1", "pod1"): {
+			metrics.NamespaceKey("ns1"): {
 				Labels: map[string]string{
 					metrics.LabelMetricSetType.Key: metrics.MetricSetTypeNamespace,
 					metrics.LabelNamespaceName.Key: "ns1",
@@ -44,10 +44,18 @@ func TestClusterAggregate(t *testing.T) {
 						ValueType: metrics.ValueInt64,
 						IntValue:  222,
 					},
+                    metrics.MetricPodCount.Name: {
+                        ValueType: metrics.ValueInt64,
+                        IntValue: 1,
+                    },
+                    metrics.MetricPodContainerCount.Name: {
+                        ValueType: metrics.ValueInt64,
+                        IntValue: 1,
+                    },
 				},
 			},
 
-			metrics.PodKey("ns1", "pod2"): {
+			metrics.NamespaceKey("ns2"): {
 				Labels: map[string]string{
 					metrics.LabelMetricSetType.Key: metrics.MetricSetTypeNamespace,
 					metrics.LabelNamespaceName.Key: "ns1",
@@ -61,6 +69,14 @@ func TestClusterAggregate(t *testing.T) {
 						ValueType: metrics.ValueInt64,
 						IntValue:  30,
 					},
+                    metrics.MetricPodCount.Name: {
+                        ValueType: metrics.ValueInt64,
+                        IntValue: 2,
+                    },
+                    metrics.MetricPodContainerCount.Name: {
+                        ValueType: metrics.ValueInt64,
+                        IntValue: 2,
+                    },
 				},
 			},
 		},
@@ -80,4 +96,12 @@ func TestClusterAggregate(t *testing.T) {
 	m3, found := cluster.Values["m3"]
 	assert.True(t, found)
 	assert.Equal(t, int64(30), m3.IntValue)
+
+    podCount, found := cluster.Values[metrics.MetricPodCount.Name]
+    assert.True(t, found)
+    assert.Equal(t, int64(3), podCount.IntValue)
+
+    podContainerCount, found := cluster.Values[metrics.MetricPodContainerCount.Name]
+    assert.True(t, found)
+    assert.Equal(t, int64(3), podContainerCount.IntValue)
 }

--- a/plugins/processors/cluster_aggregator_test.go
+++ b/plugins/processors/cluster_aggregator_test.go
@@ -44,14 +44,14 @@ func TestClusterAggregate(t *testing.T) {
 						ValueType: metrics.ValueInt64,
 						IntValue:  222,
 					},
-                    metrics.MetricPodCount.Name: {
-                        ValueType: metrics.ValueInt64,
-                        IntValue: 1,
-                    },
-                    metrics.MetricPodContainerCount.Name: {
-                        ValueType: metrics.ValueInt64,
-                        IntValue: 1,
-                    },
+					metrics.MetricPodCount.Name: {
+						ValueType: metrics.ValueInt64,
+						IntValue:  1,
+					},
+					metrics.MetricPodContainerCount.Name: {
+						ValueType: metrics.ValueInt64,
+						IntValue:  1,
+					},
 				},
 			},
 
@@ -69,14 +69,14 @@ func TestClusterAggregate(t *testing.T) {
 						ValueType: metrics.ValueInt64,
 						IntValue:  30,
 					},
-                    metrics.MetricPodCount.Name: {
-                        ValueType: metrics.ValueInt64,
-                        IntValue: 2,
-                    },
-                    metrics.MetricPodContainerCount.Name: {
-                        ValueType: metrics.ValueInt64,
-                        IntValue: 2,
-                    },
+					metrics.MetricPodCount.Name: {
+						ValueType: metrics.ValueInt64,
+						IntValue:  2,
+					},
+					metrics.MetricPodContainerCount.Name: {
+						ValueType: metrics.ValueInt64,
+						IntValue:  2,
+					},
 				},
 			},
 		},
@@ -97,11 +97,11 @@ func TestClusterAggregate(t *testing.T) {
 	assert.True(t, found)
 	assert.Equal(t, int64(30), m3.IntValue)
 
-    podCount, found := cluster.Values[metrics.MetricPodCount.Name]
-    assert.True(t, found)
-    assert.Equal(t, int64(3), podCount.IntValue)
+	podCount, found := cluster.Values[metrics.MetricPodCount.Name]
+	assert.True(t, found)
+	assert.Equal(t, int64(3), podCount.IntValue)
 
-    podContainerCount, found := cluster.Values[metrics.MetricPodContainerCount.Name]
-    assert.True(t, found)
-    assert.Equal(t, int64(3), podContainerCount.IntValue)
+	podContainerCount, found := cluster.Values[metrics.MetricPodContainerCount.Name]
+	assert.True(t, found)
+	assert.Equal(t, int64(3), podContainerCount.IntValue)
 }

--- a/plugins/processors/namespace_aggregator.go
+++ b/plugins/processors/namespace_aggregator.go
@@ -28,13 +28,13 @@ func NewNamespaceAggregator(metricsToAggregate []string) metrics.Processor {
 		{
 			ResourceSumMetrics:  metricsToAggregate,
 			ResourceCountMetric: metrics.MetricPodCount.Name,
-			isPartOfGroup:       isAggregatablePod,
+			IsPartOfGroup:       isAggregatablePod,
 			Group:               namespaceGroup,
 		},
 		{
 			ResourceSumMetrics:  []string{},
 			ResourceCountMetric: metrics.MetricPodContainerCount.Name,
-			isPartOfGroup:       isAggregatablePodContainer,
+			IsPartOfGroup:       isAggregatablePodContainer,
 			Group:               namespaceGroup,
 		},
 	})

--- a/plugins/processors/namespace_aggregator.go
+++ b/plugins/processors/namespace_aggregator.go
@@ -18,8 +18,9 @@
 package processors
 
 import (
-    "fmt"
-    "github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/metrics"
+	"fmt"
+
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/metrics"
 )
 
 type NamespaceAggregator struct {
@@ -31,28 +32,28 @@ func (aggregator *NamespaceAggregator) Name() string {
 }
 
 func (aggregator *NamespaceAggregator) Process(batch *metrics.Batch) (*metrics.Batch, error) {
-    err := aggregateByGroup(batch, groupByNamespace, isAggregatablePod, &metrics.MetricPodCount, aggregator.MetricsToAggregate)
-    if err != nil {
-        return nil, err
-    }
-    err = aggregateByGroup(batch, groupByNamespace, isAggregatablePodContainer, &metrics.MetricPodContainerCount, []string{})
-    if err != nil {
-        return nil, err
-    }
-    return batch, err
+	err := aggregateByGroup(batch, groupByNamespace, isAggregatablePod, &metrics.MetricPodCount, aggregator.MetricsToAggregate)
+	if err != nil {
+		return nil, err
+	}
+	err = aggregateByGroup(batch, groupByNamespace, isAggregatablePodContainer, &metrics.MetricPodContainerCount, []string{})
+	if err != nil {
+		return nil, err
+	}
+	return batch, err
 }
 
 func groupByNamespace(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
-    namespaceName, found := resourceSet.Labels[metrics.LabelNamespaceName.Key]
-    if !found {
-        return "", nil, fmt.Errorf("no namespace info in pod %s: %v", resourceKey, resourceSet.Labels)
-    }
-    namespaceKey := metrics.NamespaceKey(namespaceName)
-    namespaceSet := batch.Sets[namespaceKey]
-    if namespaceSet == nil {
-        namespaceSet = namespaceMetricSet(namespaceName, resourceSet.Labels[metrics.LabelPodNamespaceUID.Key])
-    }
-    return namespaceKey, namespaceSet, nil
+	namespaceName, found := resourceSet.Labels[metrics.LabelNamespaceName.Key]
+	if !found {
+		return "", nil, fmt.Errorf("no namespace info in pod %s: %v", resourceKey, resourceSet.Labels)
+	}
+	namespaceKey := metrics.NamespaceKey(namespaceName)
+	namespaceSet := batch.Sets[namespaceKey]
+	if namespaceSet == nil {
+		namespaceSet = namespaceMetricSet(namespaceName, resourceSet.Labels[metrics.LabelPodNamespaceUID.Key])
+	}
+	return namespaceKey, namespaceSet, nil
 }
 
 func namespaceMetricSet(namespaceName, uid string) *metrics.Set {

--- a/plugins/processors/namespace_aggregator_test.go
+++ b/plugins/processors/namespace_aggregator_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/metrics"
 
-    corev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestNamespaceAggregate(t *testing.T) {
@@ -47,44 +47,44 @@ func TestNamespaceAggregate(t *testing.T) {
 						IntValue:  222,
 					},
 				},
-                LabeledValues: []metrics.LabeledValue{
-                    {
-                        Name:   metrics.MetricPodPhase.Name,
-                        Labels: map[string]string{"phase": string(corev1.PodSucceeded)},
-                        Value: metrics.Value{
-                            ValueType: metrics.ValueInt64,
-                            IntValue:  convertPhase(corev1.PodSucceeded),
-                        },
-                    },
-                },
+				LabeledValues: []metrics.LabeledValue{
+					{
+						Name:   metrics.MetricPodPhase.Name,
+						Labels: map[string]string{"phase": string(corev1.PodSucceeded)},
+						Value: metrics.Value{
+							ValueType: metrics.ValueInt64,
+							IntValue:  convertPhase(corev1.PodSucceeded),
+						},
+					},
+				},
 			},
 
-            metrics.PodContainerKey("ns1", "pod1", "container1"): {
-                Labels: map[string]string{
-                    metrics.LabelMetricSetType.Key: metrics.MetricSetTypePodContainer,
-                    metrics.LabelNamespaceName.Key: "ns1",
-                },
-                Values: map[string]metrics.Value{
-                    "m1": {
-                        ValueType: metrics.ValueInt64,
-                        IntValue:  10,
-                    },
-                    "m2": {
-                        ValueType: metrics.ValueInt64,
-                        IntValue:  222,
-                    },
-                },
-                LabeledValues: []metrics.LabeledValue{
-                    {
-                        Name:   metrics.MetricContainerStatus.Name,
-                        Labels: map[string]string{"state": "terminated"},
-                        Value: metrics.Value{
-                            ValueType: metrics.ValueInt64,
-                            IntValue:  3,
-                        },
-                    },
-                },
-            },
+			metrics.PodContainerKey("ns1", "pod1", "container1"): {
+				Labels: map[string]string{
+					metrics.LabelMetricSetType.Key: metrics.MetricSetTypePodContainer,
+					metrics.LabelNamespaceName.Key: "ns1",
+				},
+				Values: map[string]metrics.Value{
+					"m1": {
+						ValueType: metrics.ValueInt64,
+						IntValue:  10,
+					},
+					"m2": {
+						ValueType: metrics.ValueInt64,
+						IntValue:  222,
+					},
+				},
+				LabeledValues: []metrics.LabeledValue{
+					{
+						Name:   metrics.MetricContainerStatus.Name,
+						Labels: map[string]string{"state": "terminated"},
+						Value: metrics.Value{
+							ValueType: metrics.ValueInt64,
+							IntValue:  3,
+						},
+					},
+				},
+			},
 
 			metrics.PodKey("ns1", "pod2"): {
 				Labels: map[string]string{
@@ -103,22 +103,22 @@ func TestNamespaceAggregate(t *testing.T) {
 				},
 			},
 
-            metrics.PodContainerKey("ns1", "pod2", "container2"): {
-                Labels: map[string]string{
-                    metrics.LabelMetricSetType.Key: metrics.MetricSetTypePodContainer,
-                    metrics.LabelNamespaceName.Key: "ns1",
-                },
-                Values: map[string]metrics.Value{
-                    "m1": {
-                        ValueType: metrics.ValueInt64,
-                        IntValue:  100,
-                    },
-                    "m3": {
-                        ValueType: metrics.ValueInt64,
-                        IntValue:  30,
-                    },
-                },
-            },
+			metrics.PodContainerKey("ns1", "pod2", "container2"): {
+				Labels: map[string]string{
+					metrics.LabelMetricSetType.Key: metrics.MetricSetTypePodContainer,
+					metrics.LabelNamespaceName.Key: "ns1",
+				},
+				Values: map[string]metrics.Value{
+					"m1": {
+						ValueType: metrics.ValueInt64,
+						IntValue:  100,
+					},
+					"m3": {
+						ValueType: metrics.ValueInt64,
+						IntValue:  30,
+					},
+				},
+			},
 		},
 	}
 	processor := NamespaceAggregator{
@@ -137,11 +137,11 @@ func TestNamespaceAggregate(t *testing.T) {
 	assert.True(t, found)
 	assert.Equal(t, int64(30), m3.IntValue)
 
-    podCount, found := namespace.Values[metrics.MetricPodCount.Name]
-    assert.True(t, found)
-    assert.Equal(t, int64(1), podCount.IntValue)
+	podCount, found := namespace.Values[metrics.MetricPodCount.Name]
+	assert.True(t, found)
+	assert.Equal(t, int64(1), podCount.IntValue)
 
-    podContainerCount, found := namespace.Values[metrics.MetricPodContainerCount.Name]
-    assert.True(t, found)
-    assert.Equal(t, int64(1), podContainerCount.IntValue)
+	podContainerCount, found := namespace.Values[metrics.MetricPodContainerCount.Name]
+	assert.True(t, found)
+	assert.Equal(t, int64(1), podContainerCount.IntValue)
 }

--- a/plugins/processors/node_aggregator.go
+++ b/plugins/processors/node_aggregator.go
@@ -18,8 +18,9 @@
 package processors
 
 import (
-    "fmt"
-    log "github.com/sirupsen/logrus"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
 	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/metrics"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -50,27 +51,27 @@ func aggregateByGroup(batch *metrics.Batch, extractGroupSet func(batch *metrics.
 		if !shouldAggregate(resourceSet) {
 			continue
 		}
-        groupKey, groupSet, err := extractGroupSet(batch, resourceKey, resourceSet)
-        if err != nil {
-            log.Errorf(err.Error())
-            continue
-        }
+		groupKey, groupSet, err := extractGroupSet(batch, resourceKey, resourceSet)
+		if err != nil {
+			log.Errorf(err.Error())
+			continue
+		}
 		aggregateCount(resourceSet, groupSet, count.Name)
 		if err := aggregate(resourceSet, groupSet, metricsToAggregate); err != nil {
 			return err
 		}
-        batch.Sets[groupKey] = groupSet
+		batch.Sets[groupKey] = groupSet
 	}
 	return nil
 }
 
 func groupByNode(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
-    nodeName := resourceSet.Labels[metrics.LabelNodename.Key]
-    if nodeName == "" {
-        return "", nil, fmt.Errorf("no node info for resource %s: %v", resourceKey, resourceSet.Labels)
-    }
-    nodeKey := metrics.NodeKey(nodeName)
-    return nodeKey, batch.Sets[nodeKey], nil
+	nodeName := resourceSet.Labels[metrics.LabelNodename.Key]
+	if nodeName == "" {
+		return "", nil, fmt.Errorf("no node info for resource %s: %v", resourceKey, resourceSet.Labels)
+	}
+	nodeKey := metrics.NodeKey(nodeName)
+	return nodeKey, batch.Sets[nodeKey], nil
 }
 
 func isAggregatablePod(set *metrics.Set) bool {
@@ -82,9 +83,9 @@ func isAggregatablePodContainer(set *metrics.Set) bool {
 }
 
 func isType(matchType string) func(*metrics.Set) bool {
-    return func(set *metrics.Set) bool {
-        return set.Labels[metrics.LabelMetricSetType.Key] == matchType
-    }
+	return func(set *metrics.Set) bool {
+		return set.Labels[metrics.LabelMetricSetType.Key] == matchType
+	}
 }
 
 func podTakesUpResources(set *metrics.Set) bool {

--- a/plugins/processors/node_aggregator.go
+++ b/plugins/processors/node_aggregator.go
@@ -28,13 +28,13 @@ func NewNodeAggregator(metricsToAggregate []string) metrics.Processor {
 		{
 			ResourceSumMetrics:  metricsToAggregate,
 			ResourceCountMetric: metrics.MetricPodCount.Name,
-			isPartOfGroup:       isAggregatablePod,
+			IsPartOfGroup:       isAggregatablePod,
 			Group:               nodeGroup,
 		},
 		{
 			ResourceSumMetrics:  []string{},
 			ResourceCountMetric: metrics.MetricPodContainerCount.Name,
-			isPartOfGroup:       isAggregatablePodContainer,
+			IsPartOfGroup:       isAggregatablePodContainer,
 			Group:               nodeGroup,
 		},
 	})

--- a/plugins/processors/node_aggregator.go
+++ b/plugins/processors/node_aggregator.go
@@ -19,11 +19,11 @@ package processors
 
 import (
 	log "github.com/sirupsen/logrus"
-
 	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/metrics"
+	corev1 "k8s.io/api/core/v1"
 )
 
-// Does not add any nodes.
+// NodeAggregator aggregates MetricsToAggregate for pods by nodes. It produces by-node counts for pods and pod containers.
 type NodeAggregator struct {
 	MetricsToAggregate []string
 }
@@ -33,40 +33,59 @@ func (aggregator *NodeAggregator) Name() string {
 }
 
 func (aggregator *NodeAggregator) Process(batch *metrics.Batch) (*metrics.Batch, error) {
-	for key, metricSet := range batch.Sets {
-		metricSetType, found := metricSet.Labels[metrics.LabelMetricSetType.Key]
-		if !found || (metricSetType != metrics.MetricSetTypePod && metricSetType != metrics.MetricSetTypePodContainer) {
-			continue
-		}
+	err := aggregateByNode(batch, isAggregatablePod, &metrics.MetricPodCount, aggregator.MetricsToAggregate)
+	if err != nil {
+		return nil, err
+	}
+	err = aggregateByNode(batch, isAggregatablePodContainer, &metrics.MetricPodContainerCount, []string{})
+	if err != nil {
+		return nil, err
+	}
+	return batch, err
+}
 
-		// Aggregating pods
-		nodeName, found := metricSet.Labels[metrics.LabelNodename.Key]
-		if nodeName == "" {
-			log.Debugf("Skipping pod %s: no node info", key)
+func aggregateByNode(batch *metrics.Batch, shouldAggregate func(*metrics.Set) bool, count *metrics.Metric, metricsToAggregate []string) error {
+	for resourceKey, resourceSet := range batch.Sets {
+		if !shouldAggregate(resourceSet) {
 			continue
 		}
-		if !found {
-			log.Errorf("No node info in pod %s: %v", key, metricSet.Labels)
+		nodeName, _ := resourceSet.Labels[metrics.LabelNodename.Key]
+		if nodeName == "" {
+			log.Errorf("No node info for resource %s: %v", resourceKey, resourceSet.Labels)
 			continue
 		}
 		nodeKey := metrics.NodeKey(nodeName)
-		node, found := batch.Sets[nodeKey]
-		if !found {
+		node := batch.Sets[nodeKey]
+		if node == nil {
 			log.Infof("No metric for node %s, cannot perform node level aggregation.", nodeKey)
-		} else {
-			if metricSetType == metrics.MetricSetTypePodContainer {
-				// aggregate container counts and continue to top of the loop
-				aggregateCount(metricSet, node, metrics.MetricPodContainerCount.Name)
-				continue
-			} else {
-				// aggregate pod counts
-				aggregateCount(metricSet, node, metrics.MetricPodCount.Name)
-			}
-
-			if err := aggregate(metricSet, node, aggregator.MetricsToAggregate); err != nil {
-				return nil, err
-			}
+			continue
+		}
+		aggregateCount(resourceSet, node, count.Name)
+		if err := aggregate(resourceSet, node, metricsToAggregate); err != nil {
+			return err
 		}
 	}
-	return batch, nil
+	return nil
+}
+
+func isAggregatablePod(set *metrics.Set) bool {
+	return isType(set, metrics.MetricSetTypePod) && podTakesUpResources(set)
+}
+
+func isAggregatablePodContainer(set *metrics.Set) bool {
+	return isType(set, metrics.MetricSetTypePodContainer) && podContainerTakesUpResources(set)
+}
+
+func isType(set *metrics.Set, matchType string) bool {
+	return set.Labels[metrics.LabelMetricSetType.Key] == matchType
+}
+
+func podTakesUpResources(set *metrics.Set) bool {
+	labels, _ := set.FindLabels(metrics.MetricPodPhase.Name)
+	return labels["phase"] != string(corev1.PodSucceeded) && labels["phase"] != string(corev1.PodFailed)
+}
+
+func podContainerTakesUpResources(set *metrics.Set) bool {
+	labels, _ := set.FindLabels(metrics.MetricContainerStatus.Name)
+	return labels["state"] != "terminated"
 }

--- a/plugins/processors/node_aggregator_test.go
+++ b/plugins/processors/node_aggregator_test.go
@@ -38,56 +38,38 @@ func TestNodeAggregate(t *testing.T) {
 					metrics.LabelNamespaceName.Key: "ns1",
 					metrics.LabelNodename.Key:      "h1",
 				},
-				Values: map[string]metrics.Value{
-					"m1": {
+				Values: map[string]metrics.Value{"m1": {
+					ValueType: metrics.ValueInt64,
+					IntValue:  10,
+				}},
+				LabeledValues: []metrics.LabeledValue{{
+					Name:   metrics.MetricPodPhase.Name,
+					Labels: map[string]string{"phase": string(corev1.PodSucceeded)},
+					Value: metrics.Value{
 						ValueType: metrics.ValueInt64,
-						IntValue:  10,
+						IntValue:  convertPhase(corev1.PodSucceeded),
 					},
-					"m2": {
-						ValueType: metrics.ValueInt64,
-						IntValue:  222,
-					},
-				},
-				LabeledValues: []metrics.LabeledValue{
-					{
-						Name:   metrics.MetricPodPhase.Name,
-						Labels: map[string]string{"phase": string(corev1.PodSucceeded)},
-						Value: metrics.Value{
-							ValueType: metrics.ValueInt64,
-							IntValue:  convertPhase(corev1.PodSucceeded),
-						},
-					},
-				},
+				}},
 			},
-
 			metrics.PodContainerKey("ns1", "pod1", "container1"): {
 				Labels: map[string]string{
 					metrics.LabelMetricSetType.Key: metrics.MetricSetTypePodContainer,
 					metrics.LabelNamespaceName.Key: "ns1",
 					metrics.LabelNodename.Key:      "h1",
 				},
-				Values: map[string]metrics.Value{
-					"m1": {
+				Values: map[string]metrics.Value{"m1": {
+					ValueType: metrics.ValueInt64,
+					IntValue:  10,
+				}},
+				LabeledValues: []metrics.LabeledValue{{
+					Name:   metrics.MetricContainerStatus.Name,
+					Labels: map[string]string{"state": "terminated"},
+					Value: metrics.Value{
 						ValueType: metrics.ValueInt64,
-						IntValue:  10,
+						IntValue:  3,
 					},
-					"m2": {
-						ValueType: metrics.ValueInt64,
-						IntValue:  222,
-					},
-				},
-				LabeledValues: []metrics.LabeledValue{
-					{
-						Name:   metrics.MetricContainerStatus.Name,
-						Labels: map[string]string{"state": "terminated"},
-						Value: metrics.Value{
-							ValueType: metrics.ValueInt64,
-							IntValue:  3,
-						},
-					},
-				},
+				}},
 			},
-
 			metrics.PodKey("ns1", "pod2"): {
 				Labels: map[string]string{
 					metrics.LabelMetricSetType.Key: metrics.MetricSetTypePod,
@@ -105,25 +87,17 @@ func TestNodeAggregate(t *testing.T) {
 					},
 				},
 			},
-
 			metrics.PodContainerKey("ns1", "pod2", "container2"): {
 				Labels: map[string]string{
 					metrics.LabelMetricSetType.Key: metrics.MetricSetTypePodContainer,
 					metrics.LabelNamespaceName.Key: "ns1",
 					metrics.LabelNodename.Key:      "h1",
 				},
-				Values: map[string]metrics.Value{
-					"m1": {
-						ValueType: metrics.ValueInt64,
-						IntValue:  10,
-					},
-					"m2": {
-						ValueType: metrics.ValueInt64,
-						IntValue:  222,
-					},
-				},
+				Values: map[string]metrics.Value{"m1": {
+					ValueType: metrics.ValueInt64,
+					IntValue:  10,
+				}},
 			},
-
 			metrics.NodeKey("h1"): {
 				Labels: map[string]string{
 					metrics.LabelMetricSetType.Key: metrics.MetricSetTypeNode,
@@ -133,27 +107,15 @@ func TestNodeAggregate(t *testing.T) {
 			},
 		},
 	}
-	processor := NodeAggregator{
-		MetricsToAggregate: []string{"m1", "m3"},
-	}
+	processor := NewNodeAggregator([]string{"m1", "m3"})
 	result, err := processor.Process(&batch)
 	assert.NoError(t, err)
-	node, found := result.Sets[metrics.NodeKey("h1")]
-	assert.True(t, found)
 
-	m1, found := node.Values["m1"]
-	assert.True(t, found)
-	assert.Equal(t, int64(100), m1.IntValue)
+	node := result.Sets[metrics.NodeKey("h1")]
+	assert.NotNil(t, node)
 
-	m3, found := node.Values["m3"]
-	assert.True(t, found)
-	assert.Equal(t, int64(30), m3.IntValue)
-
-	podCount, found := node.Values[metrics.MetricPodCount.Name]
-	assert.True(t, found)
-	assert.Equal(t, int64(1), podCount.IntValue)
-
-	podContainerCount, found := node.Values[metrics.MetricPodContainerCount.Name]
-	assert.True(t, found)
-	assert.Equal(t, int64(1), podContainerCount.IntValue)
+	assert.Equal(t, int64(100), node.Values["m1"].IntValue)
+	assert.Equal(t, int64(30), node.Values["m3"].IntValue)
+	assert.Equal(t, int64(1), node.Values[metrics.MetricPodCount.Name].IntValue)
+	assert.Equal(t, int64(1), node.Values[metrics.MetricPodContainerCount.Name].IntValue)
 }

--- a/plugins/processors/sum_count_aggregator.go
+++ b/plugins/processors/sum_count_aggregator.go
@@ -1,0 +1,77 @@
+package processors
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/metrics"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type SumCountAggregator struct {
+	name  string
+	specs []SumCountAggregateSpec
+}
+
+type SumCountAggregateSpec struct {
+	ResourceSumMetrics  []string
+	ResourceCountMetric string
+	ShouldAggregate     func(*metrics.Set) bool
+	ExtractGroup        func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error)
+}
+
+func NewSumCountAggregator(name string, specs []SumCountAggregateSpec) *SumCountAggregator {
+	return &SumCountAggregator{name, specs}
+}
+
+func (a *SumCountAggregator) Name() string {
+	return fmt.Sprintf("%s_aggregator", a.name)
+}
+
+func (a *SumCountAggregator) Process(batch *metrics.Batch) (*metrics.Batch, error) {
+	for _, spec := range a.specs {
+		for resourceKey, resourceSet := range batch.Sets {
+			if !spec.ShouldAggregate(resourceSet) {
+				continue
+			}
+			groupKey, groupSet, err := spec.ExtractGroup(batch, resourceKey, resourceSet)
+			if err != nil {
+				log.Errorf(err.Error())
+				continue
+			}
+			if groupSet == nil {
+				continue
+			}
+			aggregateCount(resourceSet, groupSet, spec.ResourceCountMetric)
+			if err := aggregate(resourceSet, groupSet, spec.ResourceSumMetrics); err != nil {
+				return nil, err
+			}
+			batch.Sets[groupKey] = groupSet
+		}
+	}
+	return batch, nil
+}
+
+func isAggregatablePod(set *metrics.Set) bool {
+	return isType(metrics.MetricSetTypePod)(set) && podTakesUpResources(set)
+}
+
+func isAggregatablePodContainer(set *metrics.Set) bool {
+	return isType(metrics.MetricSetTypePodContainer)(set) && podContainerTakesUpResources(set)
+}
+
+func isType(matchType string) func(*metrics.Set) bool {
+	return func(set *metrics.Set) bool {
+		return set.Labels[metrics.LabelMetricSetType.Key] == matchType
+	}
+}
+
+func podTakesUpResources(set *metrics.Set) bool {
+	labels, _ := set.FindLabels(metrics.MetricPodPhase.Name)
+	return labels["phase"] != string(corev1.PodSucceeded) && labels["phase"] != string(corev1.PodFailed)
+}
+
+func podContainerTakesUpResources(set *metrics.Set) bool {
+	labels, _ := set.FindLabels(metrics.MetricContainerStatus.Name)
+	return labels["state"] != "terminated"
+}

--- a/plugins/processors/sum_count_aggregator.go
+++ b/plugins/processors/sum_count_aggregator.go
@@ -15,7 +15,7 @@ type SumCountAggregator struct {
 type SumCountAggregateSpec struct {
 	ResourceSumMetrics  []string
 	ResourceCountMetric string
-	isPartOfGroup       func(*metrics.Set) bool
+	IsPartOfGroup       func(*metrics.Set) bool
 	Group               func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set)
 }
 
@@ -30,7 +30,7 @@ func (a *SumCountAggregator) Name() string {
 func (a *SumCountAggregator) Process(batch *metrics.Batch) (*metrics.Batch, error) {
 	for _, spec := range a.specs {
 		for resourceKey, resourceSet := range batch.Sets {
-			if !spec.isPartOfGroup(resourceSet) {
+			if !spec.IsPartOfGroup(resourceSet) {
 				continue
 			}
 			groupKey, groupSet := spec.Group(batch, resourceKey, resourceSet)

--- a/plugins/processors/sum_count_aggregator_test.go
+++ b/plugins/processors/sum_count_aggregator_test.go
@@ -19,14 +19,14 @@ func TestSumCountAggregator(t *testing.T) {
 		groupKey := metrics.ResourceKey("group")
 		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
 			ResourceSumMetrics: []string{},
-			ShouldAggregate: func(_ *metrics.Set) bool {
+			isPartOfGroup: func(_ *metrics.Set) bool {
 				return true
 			},
-			ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+			Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
 				return groupKey, &metrics.Set{
 					Labels: map[string]string{},
 					Values: map[string]metrics.Value{},
-				}, nil
+				}
 			},
 		}})
 		inputBatch := &metrics.Batch{
@@ -50,11 +50,11 @@ func TestSumCountAggregator(t *testing.T) {
 		groupKey := metrics.ResourceKey("group")
 		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
 			ResourceSumMetrics: []string{},
-			ShouldAggregate: func(_ *metrics.Set) bool {
+			isPartOfGroup: func(_ *metrics.Set) bool {
 				return true
 			},
-			ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
-				return groupKey, nil, nil
+			Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
+				return groupKey, nil
 			},
 		}})
 		inputBatch := &metrics.Batch{
@@ -78,10 +78,10 @@ func TestSumCountAggregator(t *testing.T) {
 		groupKey := metrics.ResourceKey("group")
 		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
 			ResourceSumMetrics: []string{"m1"},
-			ShouldAggregate: func(resourceSet *metrics.Set) bool {
+			isPartOfGroup: func(resourceSet *metrics.Set) bool {
 				return resourceSet.Labels["type"] == "pod"
 			},
-			ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+			Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
 				groupSet := batch.Sets[groupKey]
 				if groupSet == nil {
 					groupSet = &metrics.Set{
@@ -89,7 +89,7 @@ func TestSumCountAggregator(t *testing.T) {
 						Values: map[string]metrics.Value{},
 					}
 				}
-				return groupKey, groupSet, nil
+				return groupKey, groupSet
 			},
 		}})
 		inputBatch := &metrics.Batch{
@@ -132,10 +132,10 @@ func TestSumCountAggregator(t *testing.T) {
 		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
 			ResourceSumMetrics:  []string{"m1"},
 			ResourceCountMetric: "c1",
-			ShouldAggregate: func(resourceSet *metrics.Set) bool {
+			isPartOfGroup: func(resourceSet *metrics.Set) bool {
 				return resourceSet.Labels["type"] == "pod"
 			},
-			ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+			Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
 				groupSet := batch.Sets[groupKey]
 				if groupSet == nil {
 					groupSet = &metrics.Set{
@@ -143,7 +143,7 @@ func TestSumCountAggregator(t *testing.T) {
 						Values: map[string]metrics.Value{},
 					}
 				}
-				return groupKey, groupSet, nil
+				return groupKey, groupSet
 			},
 		}})
 		inputBatch := &metrics.Batch{
@@ -180,10 +180,10 @@ func TestSumCountAggregator(t *testing.T) {
 		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
 			ResourceSumMetrics:  []string{"m1"},
 			ResourceCountMetric: "c1",
-			ShouldAggregate: func(resourceSet *metrics.Set) bool {
+			isPartOfGroup: func(resourceSet *metrics.Set) bool {
 				return resourceSet.Labels["type"] == "pod"
 			},
-			ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+			Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
 				groupSet := batch.Sets[groupKey]
 				if groupSet == nil {
 					groupSet = &metrics.Set{
@@ -191,7 +191,7 @@ func TestSumCountAggregator(t *testing.T) {
 						Values: map[string]metrics.Value{},
 					}
 				}
-				return groupKey, groupSet, nil
+				return groupKey, groupSet
 			},
 		}})
 		inputBatch := &metrics.Batch{
@@ -241,10 +241,10 @@ func TestSumCountAggregator(t *testing.T) {
 			{
 				ResourceSumMetrics:  []string{"m1"},
 				ResourceCountMetric: "c1",
-				ShouldAggregate: func(resourceSet *metrics.Set) bool {
+				isPartOfGroup: func(resourceSet *metrics.Set) bool {
 					return resourceSet.Labels["type"] == "pod"
 				},
-				ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+				Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
 					groupSet := batch.Sets[groupKey]
 					if groupSet == nil {
 						groupSet = &metrics.Set{
@@ -252,16 +252,16 @@ func TestSumCountAggregator(t *testing.T) {
 							Values: map[string]metrics.Value{},
 						}
 					}
-					return groupKey, groupSet, nil
+					return groupKey, groupSet
 				},
 			},
 			{
 				ResourceSumMetrics:  []string{"m2"},
 				ResourceCountMetric: "c2",
-				ShouldAggregate: func(resourceSet *metrics.Set) bool {
+				isPartOfGroup: func(resourceSet *metrics.Set) bool {
 					return resourceSet.Labels["type"] == "pod_container"
 				},
-				ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+				Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
 					groupSet := batch.Sets[groupKey]
 					if groupSet == nil {
 						groupSet = &metrics.Set{
@@ -269,7 +269,7 @@ func TestSumCountAggregator(t *testing.T) {
 							Values: map[string]metrics.Value{},
 						}
 					}
-					return groupKey, groupSet, nil
+					return groupKey, groupSet
 				},
 			},
 		})

--- a/plugins/processors/sum_count_aggregator_test.go
+++ b/plugins/processors/sum_count_aggregator_test.go
@@ -1,0 +1,320 @@
+package processors
+
+import (
+	"testing"
+	"time"
+
+	"github.com/wavefronthq/wavefront-collector-for-kubernetes/internal/metrics"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSumCountAggregator(t *testing.T) {
+	t.Run("has a customizable name", func(t *testing.T) {
+		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{})
+		assert.Equal(t, sca.Name(), "my_resource_aggregator")
+	})
+
+	t.Run("adds a group set when the group can be extracted", func(t *testing.T) {
+		groupKey := metrics.ResourceKey("group")
+		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
+			ResourceSumMetrics: []string{},
+			ShouldAggregate: func(_ *metrics.Set) bool {
+				return true
+			},
+			ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+				return groupKey, &metrics.Set{
+					Labels: map[string]string{},
+					Values: map[string]metrics.Value{},
+				}, nil
+			},
+		}})
+		inputBatch := &metrics.Batch{
+			Timestamp: time.Now(),
+			Sets: map[metrics.ResourceKey]*metrics.Set{
+				metrics.PodKey("ns1", "pod1"): {
+					Labels: map[string]string{},
+					Values: map[string]metrics.Value{},
+				},
+			},
+		}
+
+		outputBatch, err := sca.Process(inputBatch)
+		assert.NoError(t, err)
+
+		groupSet := outputBatch.Sets[groupKey]
+		assert.NotNil(t, groupSet)
+	})
+
+	t.Run("does not add a group set the group can't be extracted", func(t *testing.T) {
+		groupKey := metrics.ResourceKey("group")
+		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
+			ResourceSumMetrics: []string{},
+			ShouldAggregate: func(_ *metrics.Set) bool {
+				return true
+			},
+			ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+				return groupKey, nil, nil
+			},
+		}})
+		inputBatch := &metrics.Batch{
+			Timestamp: time.Now(),
+			Sets: map[metrics.ResourceKey]*metrics.Set{
+				metrics.PodKey("ns1", "pod1"): {
+					Labels: map[string]string{},
+					Values: map[string]metrics.Value{},
+				},
+			},
+		}
+
+		outputBatch, err := sca.Process(inputBatch)
+		assert.NoError(t, err)
+
+		_, found := outputBatch.Sets[groupKey]
+		assert.False(t, found, "does not add groupKey to the outputBatch")
+	})
+
+	t.Run("sums metrics by group", func(t *testing.T) {
+		groupKey := metrics.ResourceKey("group")
+		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
+			ResourceSumMetrics: []string{"m1"},
+			ShouldAggregate: func(resourceSet *metrics.Set) bool {
+				return resourceSet.Labels["type"] == "pod"
+			},
+			ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+				groupSet := batch.Sets[groupKey]
+				if groupSet == nil {
+					groupSet = &metrics.Set{
+						Labels: map[string]string{},
+						Values: map[string]metrics.Value{},
+					}
+				}
+				return groupKey, groupSet, nil
+			},
+		}})
+		inputBatch := &metrics.Batch{
+			Timestamp: time.Now(),
+			Sets: map[metrics.ResourceKey]*metrics.Set{
+				metrics.PodKey("ns1", "pod1"): {
+					Labels: map[string]string{"type": "pod"},
+					Values: map[string]metrics.Value{
+						"m1": {
+							ValueType: metrics.ValueInt64,
+							IntValue:  1,
+						},
+						"m2": {
+							ValueType: metrics.ValueInt64,
+							IntValue:  2,
+						},
+					},
+				},
+				metrics.PodKey("ns1", "pod2"): {
+					Labels: map[string]string{"type": "pod"},
+					Values: map[string]metrics.Value{"m1": {
+						ValueType: metrics.ValueInt64,
+						IntValue:  3,
+					}},
+				},
+			},
+		}
+
+		outputBatch, err := sca.Process(inputBatch)
+		assert.NoError(t, err)
+
+		groupSet := outputBatch.Sets[groupKey]
+		assert.NotNil(t, groupSet, "groupSet should exist")
+
+		assert.Equal(t, int64(4), groupSet.Values["m1"].IntValue)
+	})
+
+	t.Run("counts resources by group", func(t *testing.T) {
+		groupKey := metrics.ResourceKey("group")
+		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
+			ResourceSumMetrics:  []string{"m1"},
+			ResourceCountMetric: "c1",
+			ShouldAggregate: func(resourceSet *metrics.Set) bool {
+				return resourceSet.Labels["type"] == "pod"
+			},
+			ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+				groupSet := batch.Sets[groupKey]
+				if groupSet == nil {
+					groupSet = &metrics.Set{
+						Labels: map[string]string{},
+						Values: map[string]metrics.Value{},
+					}
+				}
+				return groupKey, groupSet, nil
+			},
+		}})
+		inputBatch := &metrics.Batch{
+			Timestamp: time.Now(),
+			Sets: map[metrics.ResourceKey]*metrics.Set{
+				metrics.PodKey("ns1", "pod1"): {
+					Labels: map[string]string{"type": "pod"},
+					Values: map[string]metrics.Value{"m1": {
+						ValueType: metrics.ValueInt64,
+						IntValue:  1,
+					}},
+				},
+				metrics.PodKey("ns1", "pod2"): {
+					Labels: map[string]string{"type": "pod"},
+					Values: map[string]metrics.Value{"m1": {
+						ValueType: metrics.ValueInt64,
+						IntValue:  2,
+					}},
+				},
+			},
+		}
+
+		outputBatch, err := sca.Process(inputBatch)
+		assert.NoError(t, err)
+
+		groupSet := outputBatch.Sets[groupKey]
+		assert.NotNil(t, groupSet, "groupSet should exist")
+
+		assert.Equal(t, int64(2), groupSet.Values["c1"].IntValue)
+	})
+
+	t.Run("sums existing resource counts by group", func(t *testing.T) {
+		groupKey := metrics.ResourceKey("group")
+		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
+			ResourceSumMetrics:  []string{"m1"},
+			ResourceCountMetric: "c1",
+			ShouldAggregate: func(resourceSet *metrics.Set) bool {
+				return resourceSet.Labels["type"] == "pod"
+			},
+			ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+				groupSet := batch.Sets[groupKey]
+				if groupSet == nil {
+					groupSet = &metrics.Set{
+						Labels: map[string]string{},
+						Values: map[string]metrics.Value{},
+					}
+				}
+				return groupKey, groupSet, nil
+			},
+		}})
+		inputBatch := &metrics.Batch{
+			Timestamp: time.Now(),
+			Sets: map[metrics.ResourceKey]*metrics.Set{
+				metrics.PodKey("ns1", "pod1"): {
+					Labels: map[string]string{"type": "pod"},
+					Values: map[string]metrics.Value{
+						"m1": {
+							ValueType: metrics.ValueInt64,
+							IntValue:  1,
+						},
+						"c1": {
+							ValueType: metrics.ValueInt64,
+							IntValue:  2,
+						},
+					},
+				},
+				metrics.PodKey("ns1", "pod2"): {
+					Labels: map[string]string{"type": "pod"},
+					Values: map[string]metrics.Value{
+						"m1": {
+							ValueType: metrics.ValueInt64,
+							IntValue:  3,
+						},
+						"c1": {
+							ValueType: metrics.ValueInt64,
+							IntValue:  4,
+						},
+					},
+				},
+			},
+		}
+
+		outputBatch, err := sca.Process(inputBatch)
+		assert.NoError(t, err)
+
+		groupSet := outputBatch.Sets[groupKey]
+		assert.NotNil(t, groupSet, "groupSet should exist")
+
+		assert.Equal(t, int64(6), groupSet.Values["c1"].IntValue)
+	})
+
+	t.Run("handles multiple specs", func(t *testing.T) {
+		groupKey := metrics.ResourceKey("group")
+		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{
+			{
+				ResourceSumMetrics:  []string{"m1"},
+				ResourceCountMetric: "c1",
+				ShouldAggregate: func(resourceSet *metrics.Set) bool {
+					return resourceSet.Labels["type"] == "pod"
+				},
+				ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+					groupSet := batch.Sets[groupKey]
+					if groupSet == nil {
+						groupSet = &metrics.Set{
+							Labels: map[string]string{},
+							Values: map[string]metrics.Value{},
+						}
+					}
+					return groupKey, groupSet, nil
+				},
+			},
+			{
+				ResourceSumMetrics:  []string{"m2"},
+				ResourceCountMetric: "c2",
+				ShouldAggregate: func(resourceSet *metrics.Set) bool {
+					return resourceSet.Labels["type"] == "pod_container"
+				},
+				ExtractGroup: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set, error) {
+					groupSet := batch.Sets[groupKey]
+					if groupSet == nil {
+						groupSet = &metrics.Set{
+							Labels: map[string]string{},
+							Values: map[string]metrics.Value{},
+						}
+					}
+					return groupKey, groupSet, nil
+				},
+			},
+		})
+		inputBatch := &metrics.Batch{
+			Timestamp: time.Now(),
+			Sets: map[metrics.ResourceKey]*metrics.Set{
+				metrics.PodKey("ns1", "pod1"): {
+					Labels: map[string]string{"type": "pod"},
+					Values: map[string]metrics.Value{
+						"m1": {
+							ValueType: metrics.ValueInt64,
+							IntValue:  1,
+						},
+						"c1": {
+							ValueType: metrics.ValueInt64,
+							IntValue:  2,
+						},
+					},
+				},
+				metrics.PodContainerKey("ns2", "pod2", "container2"): {
+					Labels: map[string]string{"type": "pod_container"},
+					Values: map[string]metrics.Value{
+						"m2": {
+							ValueType: metrics.ValueInt64,
+							IntValue:  3,
+						},
+						"c2": {
+							ValueType: metrics.ValueInt64,
+							IntValue:  4,
+						},
+					},
+				},
+			},
+		}
+
+		outputBatch, err := sca.Process(inputBatch)
+		assert.NoError(t, err)
+
+		groupSet := outputBatch.Sets[groupKey]
+		assert.NotNil(t, groupSet, "groupSet should exist")
+
+		assert.Equal(t, int64(1), groupSet.Values["m1"].IntValue)
+		assert.Equal(t, int64(2), groupSet.Values["c1"].IntValue)
+
+		assert.Equal(t, int64(3), groupSet.Values["m2"].IntValue)
+		assert.Equal(t, int64(4), groupSet.Values["c2"].IntValue)
+	})
+}

--- a/plugins/processors/sum_count_aggregator_test.go
+++ b/plugins/processors/sum_count_aggregator_test.go
@@ -19,7 +19,7 @@ func TestSumCountAggregator(t *testing.T) {
 		groupKey := metrics.ResourceKey("group")
 		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
 			ResourceSumMetrics: []string{},
-			isPartOfGroup: func(_ *metrics.Set) bool {
+			IsPartOfGroup: func(_ *metrics.Set) bool {
 				return true
 			},
 			Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
@@ -50,7 +50,7 @@ func TestSumCountAggregator(t *testing.T) {
 		groupKey := metrics.ResourceKey("group")
 		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
 			ResourceSumMetrics: []string{},
-			isPartOfGroup: func(_ *metrics.Set) bool {
+			IsPartOfGroup: func(_ *metrics.Set) bool {
 				return true
 			},
 			Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
@@ -78,7 +78,7 @@ func TestSumCountAggregator(t *testing.T) {
 		groupKey := metrics.ResourceKey("group")
 		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
 			ResourceSumMetrics: []string{"m1"},
-			isPartOfGroup: func(resourceSet *metrics.Set) bool {
+			IsPartOfGroup: func(resourceSet *metrics.Set) bool {
 				return resourceSet.Labels["type"] == "pod"
 			},
 			Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
@@ -132,7 +132,7 @@ func TestSumCountAggregator(t *testing.T) {
 		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
 			ResourceSumMetrics:  []string{"m1"},
 			ResourceCountMetric: "c1",
-			isPartOfGroup: func(resourceSet *metrics.Set) bool {
+			IsPartOfGroup: func(resourceSet *metrics.Set) bool {
 				return resourceSet.Labels["type"] == "pod"
 			},
 			Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
@@ -180,7 +180,7 @@ func TestSumCountAggregator(t *testing.T) {
 		sca := NewSumCountAggregator("my_resource", []SumCountAggregateSpec{{
 			ResourceSumMetrics:  []string{"m1"},
 			ResourceCountMetric: "c1",
-			isPartOfGroup: func(resourceSet *metrics.Set) bool {
+			IsPartOfGroup: func(resourceSet *metrics.Set) bool {
 				return resourceSet.Labels["type"] == "pod"
 			},
 			Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
@@ -241,7 +241,7 @@ func TestSumCountAggregator(t *testing.T) {
 			{
 				ResourceSumMetrics:  []string{"m1"},
 				ResourceCountMetric: "c1",
-				isPartOfGroup: func(resourceSet *metrics.Set) bool {
+				IsPartOfGroup: func(resourceSet *metrics.Set) bool {
 					return resourceSet.Labels["type"] == "pod"
 				},
 				Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {
@@ -258,7 +258,7 @@ func TestSumCountAggregator(t *testing.T) {
 			{
 				ResourceSumMetrics:  []string{"m2"},
 				ResourceCountMetric: "c2",
-				isPartOfGroup: func(resourceSet *metrics.Set) bool {
+				IsPartOfGroup: func(resourceSet *metrics.Set) bool {
 					return resourceSet.Labels["type"] == "pod_container"
 				},
 				Group: func(batch *metrics.Batch, resourceKey metrics.ResourceKey, resourceSet *metrics.Set) (metrics.ResourceKey, *metrics.Set) {

--- a/plugins/sources/summary/converter_utils.go
+++ b/plugins/sources/summary/converter_utils.go
@@ -20,7 +20,7 @@ func sortedMetricSetKeys(m map[metrics.ResourceKey]*metrics.Set) []metrics.Resou
 		keys[i] = k
 		i++
 	}
-	sort.Sort(metrics.SetKeys(keys))
+	sort.Sort(metrics.ResourceKeys(keys))
 	return keys
 }
 


### PR DESCRIPTION
This comes with a refactor to extract common aggregation logic to `SumCountAggregator`. Node, namespace, and cluster now use it instead of implementing their own aggregators.